### PR TITLE
[DNA-320] Move Snowflake compiler to UiPath/querybuilder (i.e. the SqlKata fork)

### DIFF
--- a/QueryBuilder.Tests/Infrastructure/TestCompilersContainer.cs
+++ b/QueryBuilder.Tests/Infrastructure/TestCompilersContainer.cs
@@ -19,6 +19,7 @@ namespace SqlKata.Tests.Infrastructure
             [EngineCodes.MySql] = new MySqlCompiler(),
             [EngineCodes.Oracle] = new OracleCompiler(),
             [EngineCodes.PostgreSql] = new PostgresCompiler(),
+            [EngineCodes.Snowflake] = new SnowflakeCompiler(),
             [EngineCodes.Sqlite] = new SqliteCompiler(),
             [EngineCodes.SqlServer] = new SqlServerCompiler()
         };

--- a/QueryBuilder.Tests/Snowflake/SnowflakeParameterTests.cs
+++ b/QueryBuilder.Tests/Snowflake/SnowflakeParameterTests.cs
@@ -1,0 +1,97 @@
+using SqlKata.Compilers;
+using SqlKata.Tests.Infrastructure;
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace SqlKata.Tests.Snowflake
+{
+    public class SnowflakeParameterTests : TestSupport
+    {
+        private readonly SnowflakeCompiler compiler;
+
+        public SnowflakeParameterTests()
+        {
+            compiler = Compilers.Get<SnowflakeCompiler>(EngineCodes.Snowflake);
+        }
+
+        [Fact]
+        public void TestDateTimeParameter()
+        {
+            {
+                var dt = new DateTime(1997, 04, 13, 07, 30, 00, DateTimeKind.Utc);
+                var query = new Query()
+                    .Select("Column")
+                    .From("Table")
+                    .Where("Column", "<", dt)
+                ;
+                var ctx = new SqlResult { Query = query };
+
+                Assert.Equal("WHERE \"Column\" < ?", compiler.CompileWheres(ctx));
+                Assert.Equal(new List<object>() { "1997-04-13 07:30:00Z" }, ctx.Bindings);
+            }
+
+            Assert.IsType<ArgumentException>(
+                Assert.Throws<Exception>(() =>
+                {
+                    var dt = new DateTime(1234, 5, 6, 7, 8, 9, DateTimeKind.Local);
+                    var query = new Query()
+                        .Select("Column")
+                        .From("Table")
+                        .Where("Column", "<", dt)
+                    ;
+                    var ctx = new SqlResult { Query = query };
+                    compiler.CompileWheres(ctx);
+                })
+                .InnerException.InnerException
+            );
+
+            Assert.IsType<ArgumentException>(
+                Assert.Throws<Exception>(() =>
+                {
+                    var dt = new DateTime(1234, 5, 6, 7, 8, 9, DateTimeKind.Unspecified);
+                    var query = new Query()
+                        .Select("Column")
+                        .From("Table")
+                        .Where("Column", "<", dt)
+                    ;
+                    var ctx = new SqlResult { Query = query };
+                    compiler.CompileWheres(ctx);
+                })
+                .InnerException.InnerException
+            );
+        }
+
+        [Fact]
+        public void TestDateTimeOffsetParameter()
+        {
+            {
+                var dt = new DateTimeOffset(new DateTime(1234, 5, 6, 8, 10, 9, DateTimeKind.Unspecified), new TimeSpan(1, 2, 0));
+                var query = new Query()
+                    .Select("Column")
+                    .From("Table")
+                    .Where("Column", "<", dt)
+                ;
+                var ctx = new SqlResult { Query = query };
+
+                Assert.Equal("WHERE \"Column\" < ?", compiler.CompileWheres(ctx));
+                Assert.Equal(new List<object>() { "1234-05-06 07:08:09Z" }, ctx.Bindings);
+            }
+
+            // DateTimeKind.Local offset can vary and so not tested
+
+            {
+                var dt = new DateTimeOffset(new DateTime(1234, 5, 6, 7, 8, 9, DateTimeKind.Utc), new TimeSpan(0, 0, 0));
+                var query = new Query()
+                    .Select("Column")
+                    .From("Table")
+                    .Where("Column", "<", dt)
+                ;
+                var ctx = new SqlResult { Query = query };
+
+                Assert.Equal("WHERE \"Column\" < ?", compiler.CompileWheres(ctx));
+                Assert.Equal(new List<object>() { "1234-05-06 07:08:09Z" }, ctx.Bindings);
+            }
+        }
+    }
+}

--- a/QueryBuilder/Compilers/EngineCodes.cs
+++ b/QueryBuilder/Compilers/EngineCodes.cs
@@ -7,6 +7,7 @@ namespace SqlKata.Compilers
         public const string MySql = "mysql";
         public const string Oracle = "oracle";
         public const string PostgreSql = "postgres";
+        public const string Snowflake = "snowflake";
         public const string Sqlite = "sqlite";
         public const string SqlServer = "sqlsrv";
     }

--- a/QueryBuilder/Compilers/SnowflakeCompiler.cs
+++ b/QueryBuilder/Compilers/SnowflakeCompiler.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Linq;
+using System.Globalization;
+
+
+namespace SqlKata.Compilers
+{
+    // Snowflake-specific compiler. The SQL syntax for Snowflake is actually
+    // fairly similar with Postgres.
+    public sealed class SnowflakeCompiler : PostgresCompiler
+    {
+        public override string EngineCode { get; } = EngineCodes.Snowflake;
+
+        protected override string LastId =>
+            throw new NotSupportedException($"LastId not supported in {EngineCode} compiler");
+
+        public override string Parameter(SqlResult ctx, object parameter)
+        {
+            switch (parameter)
+            {
+                case DateTimeOffset dto:
+                    {
+                        // DateTimeOffset is always w.r.t. UTC
+                        ctx.Bindings.Add(dto.ToUniversalTime().ToString("u", CultureInfo.InvariantCulture));
+                        return "?";
+                    }
+
+                case DateTime dt:
+                    {
+                        if (dt.Kind != DateTimeKind.Utc)
+                        {
+                            throw new ArgumentException("Unsupported DateTime kind for Snowflake compiler (must be UTC)");
+                        }
+                        ctx.Bindings.Add(dt.ToUniversalTime().ToString("u", CultureInfo.InvariantCulture));
+                        return "?";
+                    }
+
+                default:
+                    {
+                        return base.Parameter(ctx, parameter);
+                    }
+            }
+        }
+
+        private static SqlResult PrepareResultForSnowflake(SqlResult ctx)
+        {
+            ctx.NamedBindings = ctx.Bindings
+                .Select((v, i) => (k: $"{i + 1}", v))
+                .ToDictionary(kv => kv.k, kv => kv.v);
+            ctx.Sql = ctx.RawSql;
+            return ctx;
+        }
+
+        public override SqlResult Compile(Query query) => PrepareResultForSnowflake(CompileRaw(query));
+    }
+}


### PR DESCRIPTION
#### From Jira issue [DNA-320](https://uipath.atlassian.net/browse/DNA-320):
> Should have any new functionality, but this is a preparatory step to adding aggregation support

Probably meant "should **not** have any new functionality".

Based on #2 and #4.