### PR TITLE
[DNA-321] Implement "AS" keywords support for aggregates.

### DIFF
--- a/QueryBuilder.Tests/AggregateTests.cs
+++ b/QueryBuilder.Tests/AggregateTests.cs
@@ -8,15 +8,15 @@ namespace SqlKata.Tests
     public class AggregateTests : TestSupport
     {
         [Fact]
-        public void AggregateAsEmpty()
+        public void SelectAggregateEmpty()
         {
-            Assert.Throws<ArgumentException>(() => new Query("A").AggregateAs("aggregate", new string[] { }));
+            Assert.Throws<ArgumentException>(() => new Query("A").SelectAggregate("aggregate", new string[] { }));
         }
 
         [Fact]
-        public void AggregateAs()
+        public void SelectAggregate()
         {
-            var query = new Query("A").AggregateAs("aggregate", new[] { "Column" });
+            var query = new Query("A").SelectAggregate("aggregate", new[] { "Column" });
 
             var c = Compile(query);
 
@@ -27,9 +27,9 @@ namespace SqlKata.Tests
         }
 
         [Fact]
-        public void AggregateAsAlias()
+        public void SelectAggregateAlias()
         {
-            var query = new Query("A").AggregateAs("aggregate", new[] { "Column" }, "Alias");
+            var query = new Query("A").SelectAggregate("aggregate", new[] { "Column" }, "Alias");
 
             var c = Compile(query);
 
@@ -40,9 +40,9 @@ namespace SqlKata.Tests
         }
 
         [Fact]
-        public void AggregateAsMultipleColumns()
+        public void SelectAggregateMultipleColumns()
         {
-            var query = new Query("A").AggregateAs("aggregate", new[] { "Column1", "Column2" });
+            var query = new Query("A").SelectAggregate("aggregate", new[] { "Column1", "Column2" });
 
             var c = Compile(query);
 
@@ -53,9 +53,9 @@ namespace SqlKata.Tests
         }
 
         [Fact]
-        public void AggregateAsMultipleColumnsAlias()
+        public void SelectAggregateMultipleColumnsAlias()
         {
-            var query = new Query("A").AggregateAs("aggregate", new[] { "Column1", "Column2" }, "Alias");
+            var query = new Query("A").SelectAggregate("aggregate", new[] { "Column1", "Column2" }, "Alias");
 
             var c = Compile(query);
 
@@ -66,9 +66,9 @@ namespace SqlKata.Tests
         }
 
         [Fact]
-        public void CountAs()
+        public void SelectCount()
         {
-            var query = new Query("A").CountAs();
+            var query = new Query("A").SelectCount();
 
             var c = Compile(query);
 
@@ -79,9 +79,9 @@ namespace SqlKata.Tests
         }
 
         [Fact]
-        public void CountAsStarAlias()
+        public void SelectCountStarAlias()
         {
-            var query = new Query("A").CountAs("*", "Alias");
+            var query = new Query("A").SelectCount("*", "Alias");
 
             var c = Compile(query);
 
@@ -92,9 +92,9 @@ namespace SqlKata.Tests
         }
 
         [Fact]
-        public void CountAsColumnAlias()
+        public void SelectCountColumnAlias()
         {
-            var query = new Query("A").CountAs("Column", "Alias");
+            var query = new Query("A").SelectCount("Column", "Alias");
 
             var c = Compile(query);
 
@@ -105,17 +105,17 @@ namespace SqlKata.Tests
         }
 
         [Fact]
-        public void CountAsDoesntModifyColumns()
+        public void SelectCountDoesntModifyColumns()
         {
             {
                 var columns = new string[] { };
-                var query = new Query("A").CountAs(columns);
+                var query = new Query("A").SelectCount(columns);
                 Compile(query);
                 Assert.Equal(columns, new string[] { });
             }
             {
                 var columns = new[] { "ColumnA", "ColumnB" };
-                var query = new Query("A").CountAs(columns);
+                var query = new Query("A").SelectCount(columns);
                 Compile(query);
                 Assert.Equal(columns, new[] { "ColumnA", "ColumnB" });
             }
@@ -124,7 +124,7 @@ namespace SqlKata.Tests
         [Fact]
         public void CountMultipleColumns()
         {
-            var query = new Query("A").CountAs(new[] { "ColumnA", "ColumnB" });
+            var query = new Query("A").SelectCount(new[] { "ColumnA", "ColumnB" });
 
             var c = Compile(query);
 
@@ -132,9 +132,9 @@ namespace SqlKata.Tests
         }
 
         [Fact]
-        public void CountAsMultipleColumns()
+        public void SelectCountMultipleColumns()
         {
-            var query = new Query("A").CountAs(new[] { "ColumnA", "ColumnB" }, "Alias");
+            var query = new Query("A").SelectCount(new[] { "ColumnA", "ColumnB" }, "Alias");
 
             var c = Compile(query);
 
@@ -144,7 +144,7 @@ namespace SqlKata.Tests
         [Fact]
         public void DistinctCount()
         {
-            var query = new Query("A").Distinct().CountAs();
+            var query = new Query("A").Distinct().SelectCount();
 
             var c = Compile(query);
 
@@ -154,7 +154,7 @@ namespace SqlKata.Tests
         [Fact]
         public void DistinctCountMultipleColumns()
         {
-            var query = new Query("A").Distinct().CountAs(new[] { "ColumnA", "ColumnB" });
+            var query = new Query("A").Distinct().SelectCount(new[] { "ColumnA", "ColumnB" });
 
             var c = Compile(query);
 
@@ -164,7 +164,7 @@ namespace SqlKata.Tests
         [Fact]
         public void Average()
         {
-            var query = new Query("A").AverageAs("TTL");
+            var query = new Query("A").SelectAverage("TTL");
 
             var c = Compile(query);
 
@@ -174,7 +174,7 @@ namespace SqlKata.Tests
         [Fact]
         public void AverageAlias()
         {
-            var query = new Query("A").AverageAs("TTL", "Alias");
+            var query = new Query("A").SelectAverage("TTL", "Alias");
 
             var c = Compile(query);
 
@@ -184,7 +184,7 @@ namespace SqlKata.Tests
         [Fact]
         public void Sum()
         {
-            var query = new Query("A").SumAs("PacketsDropped");
+            var query = new Query("A").SelectSum("PacketsDropped");
 
             var c = Compile(query);
 
@@ -194,7 +194,7 @@ namespace SqlKata.Tests
         [Fact]
         public void SumAlias()
         {
-            var query = new Query("A").SumAs("PacketsDropped", "Alias");
+            var query = new Query("A").SelectSum("PacketsDropped", "Alias");
 
             var c = Compile(query);
 
@@ -204,7 +204,7 @@ namespace SqlKata.Tests
         [Fact]
         public void Max()
         {
-            var query = new Query("A").MaxAs("LatencyMs");
+            var query = new Query("A").SelectMax("LatencyMs");
 
             var c = Compile(query);
 
@@ -214,7 +214,7 @@ namespace SqlKata.Tests
         [Fact]
         public void MaxAlias()
         {
-            var query = new Query("A").MaxAs("LatencyMs", "Alias");
+            var query = new Query("A").SelectMax("LatencyMs", "Alias");
 
             var c = Compile(query);
 
@@ -224,7 +224,7 @@ namespace SqlKata.Tests
         [Fact]
         public void Min()
         {
-            var query = new Query("A").MinAs("LatencyMs");
+            var query = new Query("A").SelectMin("LatencyMs");
 
             var c = Compile(query);
 
@@ -234,7 +234,7 @@ namespace SqlKata.Tests
         [Fact]
         public void MinAlias()
         {
-            var query = new Query("A").MinAs("LatencyMs", "Alias");
+            var query = new Query("A").SelectMin("LatencyMs", "Alias");
 
             var c = Compile(query);
 

--- a/QueryBuilder.Tests/AggregateTests.cs
+++ b/QueryBuilder.Tests/AggregateTests.cs
@@ -1,11 +1,18 @@
 using SqlKata.Compilers;
 using SqlKata.Tests.Infrastructure;
+using System;
 using Xunit;
 
 namespace SqlKata.Tests
 {
     public class AggregateTests : TestSupport
     {
+        [Fact]
+        public void AggregateAsEmpty()
+        {
+            Assert.Throws<ArgumentException>(() => new Query("A").AggregateAs("aggregate", new string[] { }));
+        }
+
         [Fact]
         public void CountAs()
         {

--- a/QueryBuilder.Tests/AggregateTests.cs
+++ b/QueryBuilder.Tests/AggregateTests.cs
@@ -7,19 +7,6 @@ namespace SqlKata.Tests
     public class AggregateTests : TestSupport
     {
         [Fact]
-        public void AsCount()
-        {
-            var query = new Query("A").AsCount();
-
-            var c = Compile(query);
-
-            Assert.Equal("SELECT COUNT(*) AS [count] FROM [A]", c[EngineCodes.SqlServer]);
-            Assert.Equal("SELECT COUNT(*) AS `count` FROM `A`", c[EngineCodes.MySql]);
-            Assert.Equal("SELECT COUNT(*) AS \"count\" FROM \"A\"", c[EngineCodes.PostgreSql]);
-            Assert.Equal("SELECT COUNT(*) AS \"COUNT\" FROM \"A\"", c[EngineCodes.Firebird]);
-        }
-
-        [Fact]
         public void CountAs()
         {
             var query = new Query("A").CountAs();
@@ -63,13 +50,13 @@ namespace SqlKata.Tests
         {
             {
                 var columns = new string[] { };
-                var query = new Query("A").AsCount(columns);
+                var query = new Query("A").CountAs(columns);
                 Compile(query);
                 Assert.Equal(columns, new string[] { });
             }
             {
                 var columns = new[] { "ColumnA", "ColumnB" };
-                var query = new Query("A").AsCount(columns);
+                var query = new Query("A").CountAs(columns);
                 Compile(query);
                 Assert.Equal(columns, new[] { "ColumnA", "ColumnB" });
             }
@@ -78,7 +65,7 @@ namespace SqlKata.Tests
         [Fact]
         public void CountMultipleColumns()
         {
-            var query = new Query("A").AsCount(new[] { "ColumnA", "ColumnB" });
+            var query = new Query("A").CountAs(new[] { "ColumnA", "ColumnB" });
 
             var c = Compile(query);
 
@@ -98,7 +85,7 @@ namespace SqlKata.Tests
         [Fact]
         public void DistinctCount()
         {
-            var query = new Query("A").Distinct().AsCount();
+            var query = new Query("A").Distinct().CountAs();
 
             var c = Compile(query);
 
@@ -108,7 +95,7 @@ namespace SqlKata.Tests
         [Fact]
         public void DistinctCountMultipleColumns()
         {
-            var query = new Query("A").Distinct().AsCount(new[] { "ColumnA", "ColumnB" });
+            var query = new Query("A").Distinct().CountAs(new[] { "ColumnA", "ColumnB" });
 
             var c = Compile(query);
 

--- a/QueryBuilder.Tests/AggregateTests.cs
+++ b/QueryBuilder.Tests/AggregateTests.cs
@@ -14,6 +14,58 @@ namespace SqlKata.Tests
         }
 
         [Fact]
+        public void AggregateAs()
+        {
+            var query = new Query("A").AggregateAs("aggregate", new[] { "Column" });
+
+            var c = Compile(query);
+
+            Assert.Equal("SELECT AGGREGATE([Column]) AS [aggregate] FROM [A]", c[EngineCodes.SqlServer]);
+            Assert.Equal("SELECT AGGREGATE(`Column`) AS `aggregate` FROM `A`", c[EngineCodes.MySql]);
+            Assert.Equal("SELECT AGGREGATE(\"Column\") AS \"aggregate\" FROM \"A\"", c[EngineCodes.PostgreSql]);
+            Assert.Equal("SELECT AGGREGATE(\"COLUMN\") AS \"AGGREGATE\" FROM \"A\"", c[EngineCodes.Firebird]);
+        }
+
+        [Fact]
+        public void AggregateAsAlias()
+        {
+            var query = new Query("A").AggregateAs("aggregate", new[] { "Column" }, "Alias");
+
+            var c = Compile(query);
+
+            Assert.Equal("SELECT AGGREGATE([Column]) AS [Alias] FROM [A]", c[EngineCodes.SqlServer]);
+            Assert.Equal("SELECT AGGREGATE(`Column`) AS `Alias` FROM `A`", c[EngineCodes.MySql]);
+            Assert.Equal("SELECT AGGREGATE(\"Column\") AS \"Alias\" FROM \"A\"", c[EngineCodes.PostgreSql]);
+            Assert.Equal("SELECT AGGREGATE(\"COLUMN\") AS \"ALIAS\" FROM \"A\"", c[EngineCodes.Firebird]);
+        }
+
+        [Fact]
+        public void AggregateAsMultipleColumns()
+        {
+            var query = new Query("A").AggregateAs("aggregate", new[] { "Column1", "Column2" });
+
+            var c = Compile(query);
+
+            Assert.Equal("SELECT AGGREGATE(*) AS [aggregate] FROM (SELECT 1 FROM [A] WHERE [Column1] IS NOT NULL AND [Column2] IS NOT NULL) AS [AggregateQuery]", c[EngineCodes.SqlServer]);
+            Assert.Equal("SELECT AGGREGATE(*) AS `aggregate` FROM (SELECT 1 FROM `A` WHERE `Column1` IS NOT NULL AND `Column2` IS NOT NULL) AS `AggregateQuery`", c[EngineCodes.MySql]);
+            Assert.Equal("SELECT AGGREGATE(*) AS \"AGGREGATE\" FROM (SELECT 1 FROM \"A\" WHERE \"COLUMN1\" IS NOT NULL AND \"COLUMN2\" IS NOT NULL) AS \"AGGREGATEQUERY\"", c[EngineCodes.Firebird]);
+            Assert.Equal("SELECT AGGREGATE(*) AS \"aggregate\" FROM (SELECT 1 FROM \"A\" WHERE \"Column1\" IS NOT NULL AND \"Column2\" IS NOT NULL) AS \"AggregateQuery\"", c[EngineCodes.PostgreSql]);
+        }
+
+        [Fact]
+        public void AggregateAsMultipleColumnsAlias()
+        {
+            var query = new Query("A").AggregateAs("aggregate", new[] { "Column1", "Column2" }, "Alias");
+
+            var c = Compile(query);
+
+            Assert.Equal("SELECT AGGREGATE(*) AS [Alias] FROM (SELECT 1 FROM [A] WHERE [Column1] IS NOT NULL AND [Column2] IS NOT NULL) AS [AliasAggregateQuery]", c[EngineCodes.SqlServer]);
+            Assert.Equal("SELECT AGGREGATE(*) AS `Alias` FROM (SELECT 1 FROM `A` WHERE `Column1` IS NOT NULL AND `Column2` IS NOT NULL) AS `AliasAggregateQuery`", c[EngineCodes.MySql]);
+            Assert.Equal("SELECT AGGREGATE(*) AS \"ALIAS\" FROM (SELECT 1 FROM \"A\" WHERE \"COLUMN1\" IS NOT NULL AND \"COLUMN2\" IS NOT NULL) AS \"ALIASAGGREGATEQUERY\"", c[EngineCodes.Firebird]);
+            Assert.Equal("SELECT AGGREGATE(*) AS \"Alias\" FROM (SELECT 1 FROM \"A\" WHERE \"Column1\" IS NOT NULL AND \"Column2\" IS NOT NULL) AS \"AliasAggregateQuery\"", c[EngineCodes.PostgreSql]);
+        }
+
+        [Fact]
         public void CountAs()
         {
             var query = new Query("A").CountAs();
@@ -112,7 +164,7 @@ namespace SqlKata.Tests
         [Fact]
         public void Average()
         {
-            var query = new Query("A").AsAverage("TTL");
+            var query = new Query("A").AverageAs("TTL");
 
             var c = Compile(query);
 
@@ -120,9 +172,19 @@ namespace SqlKata.Tests
         }
 
         [Fact]
+        public void AverageAlias()
+        {
+            var query = new Query("A").AverageAs("TTL", "Alias");
+
+            var c = Compile(query);
+
+            Assert.Equal("SELECT AVG([TTL]) AS [Alias] FROM [A]", c[EngineCodes.SqlServer]);
+        }
+
+        [Fact]
         public void Sum()
         {
-            var query = new Query("A").AsSum("PacketsDropped");
+            var query = new Query("A").SumAs("PacketsDropped");
 
             var c = Compile(query);
 
@@ -130,9 +192,19 @@ namespace SqlKata.Tests
         }
 
         [Fact]
+        public void SumAlias()
+        {
+            var query = new Query("A").SumAs("PacketsDropped", "Alias");
+
+            var c = Compile(query);
+
+            Assert.Equal("SELECT SUM([PacketsDropped]) AS [Alias] FROM [A]", c[EngineCodes.SqlServer]);
+        }
+
+        [Fact]
         public void Max()
         {
-            var query = new Query("A").AsMax("LatencyMs");
+            var query = new Query("A").MaxAs("LatencyMs");
 
             var c = Compile(query);
 
@@ -140,13 +212,33 @@ namespace SqlKata.Tests
         }
 
         [Fact]
+        public void MaxAlias()
+        {
+            var query = new Query("A").MaxAs("LatencyMs", "Alias");
+
+            var c = Compile(query);
+
+            Assert.Equal("SELECT MAX([LatencyMs]) AS [Alias] FROM [A]", c[EngineCodes.SqlServer]);
+        }
+
+        [Fact]
         public void Min()
         {
-            var query = new Query("A").AsMin("LatencyMs");
+            var query = new Query("A").MinAs("LatencyMs");
 
             var c = Compile(query);
 
             Assert.Equal("SELECT MIN([LatencyMs]) AS [min] FROM [A]", c[EngineCodes.SqlServer]);
+        }
+
+        [Fact]
+        public void MinAlias()
+        {
+            var query = new Query("A").MinAs("LatencyMs", "Alias");
+
+            var c = Compile(query);
+
+            Assert.Equal("SELECT MIN([LatencyMs]) AS [Alias] FROM [A]", c[EngineCodes.SqlServer]);
         }
     }
 }

--- a/QueryBuilder.Tests/DefineTest.cs
+++ b/QueryBuilder.Tests/DefineTest.cs
@@ -29,7 +29,7 @@ namespace SqlKata.Tests
         {
 
             var subquery = new Query("Products")
-                .AverageAs("unitprice")
+                .SelectAverage("unitprice")
                 .Define("@UnitsInSt", 10)
                 .Where("UnitsInStock", ">", Variable("@UnitsInSt"));
 
@@ -252,7 +252,7 @@ namespace SqlKata.Tests
                .Where(q =>
                    q.Where("ShipRegion", "!=", Variable("@shipReg"))
                 //    .WhereRaw("1 = @one")
-                ).CountAs();
+                ).SelectCount();
 
             var c = Compile(query);
 

--- a/QueryBuilder.Tests/DefineTest.cs
+++ b/QueryBuilder.Tests/DefineTest.cs
@@ -252,7 +252,7 @@ namespace SqlKata.Tests
                .Where(q =>
                    q.Where("ShipRegion", "!=", Variable("@shipReg"))
                 //    .WhereRaw("1 = @one")
-                ).AsCount();
+                ).CountAs();
 
             var c = Compile(query);
 

--- a/QueryBuilder.Tests/DefineTest.cs
+++ b/QueryBuilder.Tests/DefineTest.cs
@@ -29,7 +29,7 @@ namespace SqlKata.Tests
         {
 
             var subquery = new Query("Products")
-                .AsAverage("unitprice")
+                .AverageAs("unitprice")
                 .Define("@UnitsInSt", 10)
                 .Where("UnitsInStock", ">", Variable("@UnitsInSt"));
 

--- a/QueryBuilder.Tests/SelectTests.cs
+++ b/QueryBuilder.Tests/SelectTests.cs
@@ -192,7 +192,7 @@ namespace SqlKata.Tests
         [Fact]
         public void WhereSub()
         {
-            var subQuery = new Query("Table2").WhereColumns("Table2.Column", "=", "Table.MyCol").AsCount();
+            var subQuery = new Query("Table2").WhereColumns("Table2.Column", "=", "Table.MyCol").CountAs();
 
             var query = new Query("Table").WhereSub(subQuery, 1);
 
@@ -206,7 +206,7 @@ namespace SqlKata.Tests
         [Fact]
         public void OrWhereSub()
         {
-            var subQuery = new Query("Table2").WhereColumns("Table2.Column", "=", "Table.MyCol").AsCount();
+            var subQuery = new Query("Table2").WhereColumns("Table2.Column", "=", "Table.MyCol").CountAs();
 
             var query = new Query("Table").WhereNull("MyCol").OrWhereSub(subQuery, "<", 1);
 

--- a/QueryBuilder.Tests/SelectTests.cs
+++ b/QueryBuilder.Tests/SelectTests.cs
@@ -22,6 +22,32 @@ namespace SqlKata.Tests
         }
 
         [Fact]
+        public void SelectAs()
+        {
+            var query = new Query().SelectAs(("Row", "Alias")).From("Table");
+
+            var c = Compile(query);
+            Assert.Equal("SELECT [Row] AS [Alias] FROM [Table]", c[EngineCodes.SqlServer]);
+            Assert.Equal("SELECT `Row` AS `Alias` FROM `Table`", c[EngineCodes.MySql]);
+            Assert.Equal("SELECT \"Row\" AS \"Alias\" FROM \"Table\"", c[EngineCodes.PostgreSql]);
+            Assert.Equal("SELECT \"ROW\" AS \"ALIAS\" FROM \"TABLE\"", c[EngineCodes.Firebird]);
+            Assert.Equal("SELECT \"Row\" \"Alias\" FROM \"Table\"", c[EngineCodes.Oracle]);
+        }
+
+        [Fact]
+        public void SelectAsMultipleColumns()
+        {
+            var query = new Query().SelectAs(("Row1", "Alias1"), ("Row2", "Alias2")).From("Table");
+
+            var c = Compile(query);
+            Assert.Equal("SELECT [Row1] AS [Alias1], [Row2] AS [Alias2] FROM [Table]", c[EngineCodes.SqlServer]);
+            Assert.Equal("SELECT `Row1` AS `Alias1`, `Row2` AS `Alias2` FROM `Table`", c[EngineCodes.MySql]);
+            Assert.Equal("SELECT \"Row1\" AS \"Alias1\", \"Row2\" AS \"Alias2\" FROM \"Table\"", c[EngineCodes.PostgreSql]);
+            Assert.Equal("SELECT \"ROW1\" AS \"ALIAS1\", \"ROW2\" AS \"ALIAS2\" FROM \"TABLE\"", c[EngineCodes.Firebird]);
+            Assert.Equal("SELECT \"Row1\" \"Alias1\", \"Row2\" \"Alias2\" FROM \"Table\"", c[EngineCodes.Oracle]);
+        }
+
+        [Fact]
         public void BasicSelectWhereBindingIsEmptyOrNull()
         {
             var q = new Query()
@@ -58,6 +84,21 @@ namespace SqlKata.Tests
 
             Assert.Equal("SELECT [users].[id], [users].[name], [users].[age] FROM [users]", c[EngineCodes.SqlServer]);
             Assert.Equal("SELECT `users`.`id`, `users`.`name`, `users`.`age` FROM `users`", c[EngineCodes.MySql]);
+        }
+
+        [Fact]
+        public void ExpandedSelectAs()
+        {
+            var q = new Query().From("users").SelectAs(("users.{id,name, age}", "Alias"));
+            var c = Compile(q);
+
+            // This result is weird (but valid syntax), and at least it works in
+            // a somewhat explainable way, as opposed to regular Select() when
+            // combining the expanded syntax and the 'as' SQLKata keyword support
+            // which simply silently stops working when the {...} expansion is
+            // applied.
+            Assert.Equal("SELECT [users].[id] AS [Alias], [users].[name] AS [Alias], [users].[age] AS [Alias] FROM [users]", c[EngineCodes.SqlServer]);
+            Assert.Equal("SELECT `users`.`id` AS `Alias`, `users`.`name` AS `Alias`, `users`.`age` AS `Alias` FROM `users`", c[EngineCodes.MySql]);
         }
 
         [Fact]

--- a/QueryBuilder.Tests/SelectTests.cs
+++ b/QueryBuilder.Tests/SelectTests.cs
@@ -192,7 +192,7 @@ namespace SqlKata.Tests
         [Fact]
         public void WhereSub()
         {
-            var subQuery = new Query("Table2").WhereColumns("Table2.Column", "=", "Table.MyCol").CountAs();
+            var subQuery = new Query("Table2").WhereColumns("Table2.Column", "=", "Table.MyCol").SelectCount();
 
             var query = new Query("Table").WhereSub(subQuery, 1);
 
@@ -206,7 +206,7 @@ namespace SqlKata.Tests
         [Fact]
         public void OrWhereSub()
         {
-            var subQuery = new Query("Table2").WhereColumns("Table2.Column", "=", "Table.MyCol").CountAs();
+            var subQuery = new Query("Table2").WhereColumns("Table2.Column", "=", "Table.MyCol").SelectCount();
 
             var query = new Query("Table").WhereNull("MyCol").OrWhereSub(subQuery, "<", 1);
 

--- a/QueryBuilder/Clauses/AggregateClause.cs
+++ b/QueryBuilder/Clauses/AggregateClause.cs
@@ -17,6 +17,11 @@ namespace SqlKata
         public List<string> Columns { get; set; }
 
         /// <summary>
+        /// Gets or sets the alias of the result column.
+        /// </summary>
+        public string Alias { get; set; }
+
+        /// <summary>
         /// Gets or sets the type of aggregate function.
         /// </summary>
         /// <value>
@@ -32,6 +37,7 @@ namespace SqlKata
                 Engine = Engine,
                 Type = Type,
                 Columns = new List<string>(Columns),
+                Alias = Alias,
                 Component = Component,
             };
         }

--- a/QueryBuilder/Clauses/ColumnClause.cs
+++ b/QueryBuilder/Clauses/ColumnClause.cs
@@ -1,7 +1,10 @@
+using System.Diagnostics;
+
 namespace SqlKata
 {
     public abstract class AbstractColumn : AbstractClause
     {
+        public string Alias { get; set; }
     }
 
     /// <summary>
@@ -26,6 +29,7 @@ namespace SqlKata
                 Engine = Engine,
                 Name = Name,
                 Component = Component,
+                Alias = Alias,
             };
         }
     }
@@ -50,6 +54,7 @@ namespace SqlKata
                 Engine = Engine,
                 Query = Query.Clone(),
                 Component = Component,
+                Alias = Alias,
             };
         }
     }
@@ -68,6 +73,7 @@ namespace SqlKata
         /// <inheritdoc />
         public override AbstractClause Clone()
         {
+            Debug.Assert(string.IsNullOrEmpty(Alias), "Raw columns cannot have an alias");
             return new RawColumn
             {
                 Engine = Engine,

--- a/QueryBuilder/Compilers/Compiler.cs
+++ b/QueryBuilder/Compilers/Compiler.cs
@@ -449,6 +449,12 @@ namespace SqlKata.Compilers
                 return "(" + subCtx.RawSql + $"){alias}";
             }
 
+            if (!string.IsNullOrWhiteSpace(column.Alias))
+            {
+                return $"{Wrap((column as Column).Name)} {ColumnAsKeyword}{Wrap(column.Alias)}";
+
+            }
+
             return Wrap((column as Column).Name);
 
         }

--- a/QueryBuilder/Query.Aggregate.cs
+++ b/QueryBuilder/Query.Aggregate.cs
@@ -30,18 +30,6 @@ namespace SqlKata
             return this;
         }
 
-        public Query AsCount(string[] columns = null)
-        {
-            var cols = columns?.ToList() ?? new List<string> { };
-
-            if (!cols.Any())
-            {
-                cols.Add("*");
-            }
-
-            return AsAggregate("count", cols.ToArray());
-        }
-
         public Query CountAs(string column = null, string alias = null)
         {
             return CountAs(new[] { column ?? "*" }, alias);

--- a/QueryBuilder/Query.Aggregate.cs
+++ b/QueryBuilder/Query.Aggregate.cs
@@ -8,7 +8,7 @@ namespace SqlKata
         /**********************************************************************
          ** Generic aggregate                                                **
          **********************************************************************/
-        public Query AggregateAs(string type, IEnumerable<string> columns, string alias = null)
+        public Query SelectAggregate(string type, IEnumerable<string> columns, string alias = null)
         {
             if (columns.Count() == 0)
             {
@@ -32,55 +32,55 @@ namespace SqlKata
         /**********************************************************************
          ** Count                                                            **
          **********************************************************************/
-        public Query CountAs(string column = null, string alias = null)
+        public Query SelectCount(string column = null, string alias = null)
         {
-            return CountAs(column != null ? new[] { column } : new string[] { }, alias);
+            return SelectCount(column != null ? new[] { column } : new string[] { }, alias);
         }
 
-        public Query CountAs(IEnumerable<string> columns, string alias = null)
+        public Query SelectCount(IEnumerable<string> columns, string alias = null)
         {
-            return AggregateAs("count", columns.Count() == 0 ? new[] { "*" } : columns, alias);
+            return SelectAggregate("count", columns.Count() == 0 ? new[] { "*" } : columns, alias);
         }
 
 
         /**********************************************************************
          ** Average                                                          **
          **********************************************************************/
-        public Query AvgAs(string column, string alias = null)
+        public Query SelectAvg(string column, string alias = null)
         {
-            return AggregateAs("avg", new[] { column }, alias);
+            return SelectAggregate("avg", new[] { column }, alias);
         }
 
-        public Query AverageAs(string column, string alias = null)
+        public Query SelectAverage(string column, string alias = null)
         {
-            return AvgAs(column, alias);
+            return SelectAvg(column, alias);
         }
 
 
         /**********************************************************************
          ** Sum                                                              **
          **********************************************************************/
-        public Query SumAs(string column, string alias = null)
+        public Query SelectSum(string column, string alias = null)
         {
-            return AggregateAs("sum", new[] { column }, alias);
+            return SelectAggregate("sum", new[] { column }, alias);
         }
 
 
         /**********************************************************************
          ** Maximum                                                          **
          **********************************************************************/
-        public Query MaxAs(string column, string alias = null)
+        public Query SelectMax(string column, string alias = null)
         {
-            return AggregateAs("max", new[] { column }, alias);
+            return SelectAggregate("max", new[] { column }, alias);
         }
 
 
         /**********************************************************************
          ** Minimum                                                          **
          **********************************************************************/
-        public Query MinAs(string column, string alias = null)
+        public Query SelectMin(string column, string alias = null)
         {
-            return AggregateAs("min", new[] { column }, alias);
+            return SelectAggregate("min", new[] { column }, alias);
         }
     }
 }

--- a/QueryBuilder/Query.Aggregate.cs
+++ b/QueryBuilder/Query.Aggregate.cs
@@ -14,8 +14,12 @@ namespace SqlKata
             );
         }
 
-        public Query AggregateAs(string type, IEnumerable<string> columns, string alias)
+        public Query AggregateAs(string type, IEnumerable<string> columns, string alias = null)
         {
+            if (columns.Count() == 0)
+            {
+                throw new System.ArgumentException("Cannot aggregate without columns");
+            }
 
             Method = "aggregate";
 
@@ -32,12 +36,12 @@ namespace SqlKata
 
         public Query CountAs(string column = null, string alias = null)
         {
-            return CountAs(new[] { column ?? "*" }, alias);
+            return CountAs(column != null ? new[] { column } : new string[] { }, alias);
         }
 
         public Query CountAs(IEnumerable<string> columns, string alias = null)
         {
-            return AggregateAs("count", columns, alias);
+            return AggregateAs("count", columns.Count() == 0 ? new[] { "*" } : columns, alias);
         }
 
         public Query AsAvg(string column)

--- a/QueryBuilder/Query.Aggregate.cs
+++ b/QueryBuilder/Query.Aggregate.cs
@@ -7,6 +7,15 @@ namespace SqlKata
     {
         public Query AsAggregate(string type, string[] columns = null)
         {
+            return AggregateAs(
+                type,
+                columns ?? new string[] { },
+                null // old interface always uses 'type' as alias name
+            );
+        }
+
+        public Query AggregateAs(string type, IEnumerable<string> columns, string alias)
+        {
 
             Method = "aggregate";
 
@@ -14,7 +23,8 @@ namespace SqlKata
             .AddComponent("aggregate", new AggregateClause
             {
                 Type = type,
-                Columns = columns?.ToList() ?? new List<string>(),
+                Columns = columns.ToList(),
+                Alias = alias
             });
 
             return this;
@@ -30,6 +40,16 @@ namespace SqlKata
             }
 
             return AsAggregate("count", cols.ToArray());
+        }
+
+        public Query CountAs(string column = null, string alias = null)
+        {
+            return CountAs(new[] { column ?? "*" }, alias);
+        }
+
+        public Query CountAs(IEnumerable<string> columns, string alias = null)
+        {
+            return AggregateAs("count", columns, alias);
         }
 
         public Query AsAvg(string column)

--- a/QueryBuilder/Query.Aggregate.cs
+++ b/QueryBuilder/Query.Aggregate.cs
@@ -5,15 +5,9 @@ namespace SqlKata
 {
     public partial class Query
     {
-        public Query AsAggregate(string type, string[] columns = null)
-        {
-            return AggregateAs(
-                type,
-                columns ?? new string[] { },
-                null // old interface always uses 'type' as alias name
-            );
-        }
-
+        /**********************************************************************
+         ** Generic aggregate                                                **
+         **********************************************************************/
         public Query AggregateAs(string type, IEnumerable<string> columns, string alias = null)
         {
             if (columns.Count() == 0)
@@ -34,6 +28,10 @@ namespace SqlKata
             return this;
         }
 
+
+        /**********************************************************************
+         ** Count                                                            **
+         **********************************************************************/
         public Query CountAs(string column = null, string alias = null)
         {
             return CountAs(column != null ? new[] { column } : new string[] { }, alias);
@@ -44,28 +42,45 @@ namespace SqlKata
             return AggregateAs("count", columns.Count() == 0 ? new[] { "*" } : columns, alias);
         }
 
-        public Query AsAvg(string column)
+
+        /**********************************************************************
+         ** Average                                                          **
+         **********************************************************************/
+        public Query AvgAs(string column, string alias = null)
         {
-            return AsAggregate("avg", new string[] { column });
-        }
-        public Query AsAverage(string column)
-        {
-            return AsAvg(column);
+            return AggregateAs("avg", new[] { column }, alias);
         }
 
-        public Query AsSum(string column)
+        public Query AverageAs(string column, string alias = null)
         {
-            return AsAggregate("sum", new[] { column });
+            return AvgAs(column, alias);
         }
 
-        public Query AsMax(string column)
+
+        /**********************************************************************
+         ** Sum                                                              **
+         **********************************************************************/
+        public Query SumAs(string column, string alias = null)
         {
-            return AsAggregate("max", new[] { column });
+            return AggregateAs("sum", new[] { column }, alias);
         }
 
-        public Query AsMin(string column)
+
+        /**********************************************************************
+         ** Maximum                                                          **
+         **********************************************************************/
+        public Query MaxAs(string column, string alias = null)
         {
-            return AsAggregate("min", new[] { column });
+            return AggregateAs("max", new[] { column }, alias);
+        }
+
+
+        /**********************************************************************
+         ** Minimum                                                          **
+         **********************************************************************/
+        public Query MinAs(string column, string alias = null)
+        {
+            return AggregateAs("min", new[] { column }, alias);
         }
     }
 }

--- a/QueryBuilder/Query.Select.cs
+++ b/QueryBuilder/Query.Select.cs
@@ -1,26 +1,39 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace SqlKata
 {
     public partial class Query
     {
-
         public Query Select(params string[] columns)
+        {
+            return SelectAs(
+                columns
+                .Select(x => (x, null as string))
+                .ToArray()
+            );
+        }
+
+        /// <summary>
+        /// Select columns with an alias
+        /// </summary>
+        /// <returns></returns>
+        public Query SelectAs(params (string, string)[] columns)
         {
             Method = "select";
 
             columns = columns
-                .Select(x => Helper.ExpandExpression(x))
+                .Select(x => Helper.ExpandExpression(x.Item1).Select(y => (y, x.Item2)))
                 .SelectMany(x => x)
                 .ToArray();
-
 
             foreach (var column in columns)
             {
                 AddComponent("select", new Column
                 {
-                    Name = column
+                    Name = column.Item1,
+                    Alias = column.Item2
                 });
             }
 

--- a/SqlKata.Execution/Query.Extensions.cs
+++ b/SqlKata.Execution/Query.Extensions.cs
@@ -253,27 +253,27 @@ namespace SqlKata.Execution
         {
             var db = CreateQueryFactory(query);
 
-            return db.ExecuteScalar<T>(query.AggregateAs(aggregateOperation, columns), transaction, timeout);
+            return db.ExecuteScalar<T>(query.SelectAggregate(aggregateOperation, columns), transaction, timeout);
         }
 
-        public static async Task<T> AggregateAsync<T>(this Query query, string aggregateOperation, string[] columns, IDbTransaction transaction = null, int? timeout = null)
+        public static async Task<T> SelectAggregateAsync<T>(this Query query, string aggregateOperation, string[] columns, IDbTransaction transaction = null, int? timeout = null)
         {
             var db = CreateQueryFactory(query);
-            return await db.ExecuteScalarAsync<T>(query.AggregateAs(aggregateOperation, columns), transaction, timeout);
+            return await db.ExecuteScalarAsync<T>(query.SelectAggregate(aggregateOperation, columns), transaction, timeout);
         }
 
         public static T Count<T>(this Query query, string[] columns = null, IDbTransaction transaction = null, int? timeout = null)
         {
             var db = CreateQueryFactory(query);
 
-            return db.ExecuteScalar<T>(query.CountAs(columns), transaction, timeout);
+            return db.ExecuteScalar<T>(query.SelectCount(columns), transaction, timeout);
         }
 
-        public static async Task<T> CountAsync<T>(this Query query, string[] columns = null, IDbTransaction transaction = null, int? timeout = null)
+        public static async Task<T> SelectCountAsync<T>(this Query query, string[] columns = null, IDbTransaction transaction = null, int? timeout = null)
         {
             var db = CreateQueryFactory(query);
 
-            return await db.ExecuteScalarAsync<T>(query.CountAs(columns), transaction, timeout);
+            return await db.ExecuteScalarAsync<T>(query.SelectCount(columns), transaction, timeout);
         }
 
         public static T Average<T>(this Query query, string column, IDbTransaction transaction = null, int? timeout = null)
@@ -281,9 +281,9 @@ namespace SqlKata.Execution
             return query.Aggregate<T>("avg", new[] { column }, transaction, timeout);
         }
 
-        public static async Task<T> AverageAsync<T>(this Query query, string column, IDbTransaction transaction = null, int? timeout = null)
+        public static async Task<T> SelectAverageAsync<T>(this Query query, string column, IDbTransaction transaction = null, int? timeout = null)
         {
-            return await query.AggregateAsync<T>("avg", new[] { column }, transaction, timeout);
+            return await query.SelectAggregateAsync<T>("avg", new[] { column }, transaction, timeout);
         }
 
         public static T Sum<T>(this Query query, string column, IDbTransaction transaction = null, int? timeout = null)
@@ -291,9 +291,9 @@ namespace SqlKata.Execution
             return query.Aggregate<T>("sum", new[] { column }, transaction, timeout);
         }
 
-        public static async Task<T> SumAsync<T>(this Query query, string column, IDbTransaction transaction = null, int? timeout = null)
+        public static async Task<T> SelectSumAsync<T>(this Query query, string column, IDbTransaction transaction = null, int? timeout = null)
         {
-            return await query.AggregateAsync<T>("sum", new[] { column }, transaction, timeout);
+            return await query.SelectAggregateAsync<T>("sum", new[] { column }, transaction, timeout);
         }
 
         public static T Min<T>(this Query query, string column, IDbTransaction transaction = null, int? timeout = null)
@@ -301,9 +301,9 @@ namespace SqlKata.Execution
             return query.Aggregate<T>("min", new[] { column }, transaction, timeout);
         }
 
-        public static async Task<T> MinAsync<T>(this Query query, string column, IDbTransaction transaction = null, int? timeout = null)
+        public static async Task<T> SelectMinAsync<T>(this Query query, string column, IDbTransaction transaction = null, int? timeout = null)
         {
-            return await query.AggregateAsync<T>("min", new[] { column }, transaction, timeout);
+            return await query.SelectAggregateAsync<T>("min", new[] { column }, transaction, timeout);
         }
 
         public static T Max<T>(this Query query, string column, IDbTransaction transaction = null, int? timeout = null)
@@ -311,9 +311,9 @@ namespace SqlKata.Execution
             return query.Aggregate<T>("max", new[] { column }, transaction, timeout);
         }
 
-        public static async Task<T> MaxAsync<T>(this Query query, string column, IDbTransaction transaction = null, int? timeout = null)
+        public static async Task<T> SelectMaxAsync<T>(this Query query, string column, IDbTransaction transaction = null, int? timeout = null)
         {
-            return await query.AggregateAsync<T>("max", new[] { column }, transaction, timeout);
+            return await query.SelectAggregateAsync<T>("max", new[] { column }, transaction, timeout);
         }
 
         internal static XQuery CastToXQuery(Query query, string method = null)

--- a/SqlKata.Execution/Query.Extensions.cs
+++ b/SqlKata.Execution/Query.Extensions.cs
@@ -266,14 +266,14 @@ namespace SqlKata.Execution
         {
             var db = CreateQueryFactory(query);
 
-            return db.ExecuteScalar<T>(query.AsCount(columns), transaction, timeout);
+            return db.ExecuteScalar<T>(query.CountAs(columns), transaction, timeout);
         }
 
         public static async Task<T> CountAsync<T>(this Query query, string[] columns = null, IDbTransaction transaction = null, int? timeout = null)
         {
             var db = CreateQueryFactory(query);
 
-            return await db.ExecuteScalarAsync<T>(query.AsCount(columns), transaction, timeout);
+            return await db.ExecuteScalarAsync<T>(query.CountAs(columns), transaction, timeout);
         }
 
         public static T Average<T>(this Query query, string column, IDbTransaction transaction = null, int? timeout = null)

--- a/SqlKata.Execution/Query.Extensions.cs
+++ b/SqlKata.Execution/Query.Extensions.cs
@@ -253,13 +253,13 @@ namespace SqlKata.Execution
         {
             var db = CreateQueryFactory(query);
 
-            return db.ExecuteScalar<T>(query.AsAggregate(aggregateOperation, columns), transaction, timeout);
+            return db.ExecuteScalar<T>(query.AggregateAs(aggregateOperation, columns), transaction, timeout);
         }
 
         public static async Task<T> AggregateAsync<T>(this Query query, string aggregateOperation, string[] columns, IDbTransaction transaction = null, int? timeout = null)
         {
             var db = CreateQueryFactory(query);
-            return await db.ExecuteScalarAsync<T>(query.AsAggregate(aggregateOperation, columns), transaction, timeout);
+            return await db.ExecuteScalarAsync<T>(query.AggregateAs(aggregateOperation, columns), transaction, timeout);
         }
 
         public static T Count<T>(this Query query, string[] columns = null, IDbTransaction transaction = null, int? timeout = null)

--- a/SqlKata.Execution/QueryFactory.cs
+++ b/SqlKata.Execution/QueryFactory.cs
@@ -390,7 +390,7 @@ namespace SqlKata.Execution
         public T Count<T>(Query query, string[] columns = null, IDbTransaction transaction = null, int? timeout = null)
         {
             return this.ExecuteScalar<T>(
-                query.AsCount(columns),
+                query.CountAs(columns),
                 transaction,
                 timeout
             );
@@ -398,7 +398,7 @@ namespace SqlKata.Execution
 
         public async Task<T> CountAsync<T>(Query query, string[] columns = null, IDbTransaction transaction = null, int? timeout = null)
         {
-            return await this.ExecuteScalarAsync<T>(query.AsCount(columns), transaction, timeout);
+            return await this.ExecuteScalarAsync<T>(query.CountAs(columns), transaction, timeout);
         }
 
         public T Average<T>(Query query, string column, IDbTransaction transaction = null, int? timeout = null)

--- a/SqlKata.Execution/QueryFactory.cs
+++ b/SqlKata.Execution/QueryFactory.cs
@@ -369,7 +369,7 @@ namespace SqlKata.Execution
             int? timeout = null
         )
         {
-            return this.ExecuteScalar<T>(query.AsAggregate(aggregateOperation, columns), transaction, timeout ?? this.QueryTimeout);
+            return this.ExecuteScalar<T>(query.AggregateAs(aggregateOperation, columns), transaction, timeout ?? this.QueryTimeout);
         }
 
         public async Task<T> AggregateAsync<T>(
@@ -381,7 +381,7 @@ namespace SqlKata.Execution
         )
         {
             return await this.ExecuteScalarAsync<T>(
-                query.AsAggregate(aggregateOperation, columns),
+                query.AggregateAs(aggregateOperation, columns),
                 transaction,
                 timeout
             );

--- a/SqlKata.Execution/QueryFactory.cs
+++ b/SqlKata.Execution/QueryFactory.cs
@@ -369,10 +369,10 @@ namespace SqlKata.Execution
             int? timeout = null
         )
         {
-            return this.ExecuteScalar<T>(query.AggregateAs(aggregateOperation, columns), transaction, timeout ?? this.QueryTimeout);
+            return this.ExecuteScalar<T>(query.SelectAggregate(aggregateOperation, columns), transaction, timeout ?? this.QueryTimeout);
         }
 
-        public async Task<T> AggregateAsync<T>(
+        public async Task<T> SelectAggregateAsync<T>(
             Query query,
             string aggregateOperation,
             string[] columns = null,
@@ -381,7 +381,7 @@ namespace SqlKata.Execution
         )
         {
             return await this.ExecuteScalarAsync<T>(
-                query.AggregateAs(aggregateOperation, columns),
+                query.SelectAggregate(aggregateOperation, columns),
                 transaction,
                 timeout
             );
@@ -390,15 +390,15 @@ namespace SqlKata.Execution
         public T Count<T>(Query query, string[] columns = null, IDbTransaction transaction = null, int? timeout = null)
         {
             return this.ExecuteScalar<T>(
-                query.CountAs(columns),
+                query.SelectCount(columns),
                 transaction,
                 timeout
             );
         }
 
-        public async Task<T> CountAsync<T>(Query query, string[] columns = null, IDbTransaction transaction = null, int? timeout = null)
+        public async Task<T> SelectCountAsync<T>(Query query, string[] columns = null, IDbTransaction transaction = null, int? timeout = null)
         {
-            return await this.ExecuteScalarAsync<T>(query.CountAs(columns), transaction, timeout);
+            return await this.ExecuteScalarAsync<T>(query.SelectCount(columns), transaction, timeout);
         }
 
         public T Average<T>(Query query, string column, IDbTransaction transaction = null, int? timeout = null)
@@ -406,9 +406,9 @@ namespace SqlKata.Execution
             return this.Aggregate<T>(query, "avg", new[] { column });
         }
 
-        public async Task<T> AverageAsync<T>(Query query, string column)
+        public async Task<T> SelectAverageAsync<T>(Query query, string column)
         {
-            return await this.AggregateAsync<T>(query, "avg", new[] { column });
+            return await this.SelectAggregateAsync<T>(query, "avg", new[] { column });
         }
 
         public T Sum<T>(Query query, string column)
@@ -416,9 +416,9 @@ namespace SqlKata.Execution
             return this.Aggregate<T>(query, "sum", new[] { column });
         }
 
-        public async Task<T> SumAsync<T>(Query query, string column)
+        public async Task<T> SelectSumAsync<T>(Query query, string column)
         {
-            return await this.AggregateAsync<T>(query, "sum", new[] { column });
+            return await this.SelectAggregateAsync<T>(query, "sum", new[] { column });
         }
 
         public T Min<T>(Query query, string column)
@@ -426,9 +426,9 @@ namespace SqlKata.Execution
             return this.Aggregate<T>(query, "min", new[] { column });
         }
 
-        public async Task<T> MinAsync<T>(Query query, string column)
+        public async Task<T> SelectMinAsync<T>(Query query, string column)
         {
-            return await this.AggregateAsync<T>(query, "min", new[] { column });
+            return await this.SelectAggregateAsync<T>(query, "min", new[] { column });
         }
 
         public T Max<T>(Query query, string column)
@@ -436,9 +436,9 @@ namespace SqlKata.Execution
             return this.Aggregate<T>(query, "max", new[] { column });
         }
 
-        public async Task<T> MaxAsync<T>(Query query, string column)
+        public async Task<T> SelectMaxAsync<T>(Query query, string column)
         {
-            return await this.AggregateAsync<T>(query, "max", new[] { column });
+            return await this.SelectAggregateAsync<T>(query, "max", new[] { column });
         }
 
         public PaginationResult<T> Paginate<T>(Query query, int page, int perPage = 25, IDbTransaction transaction = null, int? timeout = null)
@@ -488,7 +488,7 @@ namespace SqlKata.Execution
                 throw new ArgumentException("PerPage param should be greater than or equal to 1", nameof(perPage));
             }
 
-            var count = await CountAsync<long>(query.Clone(), null, transaction, timeout);
+            var count = await SelectCountAsync<long>(query.Clone(), null, transaction, timeout);
 
             IEnumerable<T> list;
 


### PR DESCRIPTION
This is based on #3, we should coordinate review & merge order.
Also we might want to test this locally first to see if this is actually what we need to solve the switch in `BuildDataQuery()`.

This adds support for the following two syntaxes:
##### `SelectAs()`
```
Query().SelectAs(("Row1", "Alias1"), ("Row2", "Alias2")).From("Table");
--> "SELECT [Row1] AS [Alias1], [Row2] AS [Alias2] FROM [Table]"
```

##### Aggregates aliases
`AggregateAs()` supersedes `AsAggregate()`, e.g. `AsCount()` becomes `CountAs()`.
```
Query().CountAs("Column", "Alias").From("Table");
--> "SELECT COUNT([Column]) AS [Alias] FROM [Table]"
```
### Questions
1. This renames the existing aggregates from `AsCount()` to `CountAs()`, as the new function is designed as a drop-in replacement for the old one. However, we could also keep the old names around for compatibility, but then there would be two confusingly named functions with different capabilities.
2. Is `CountAs()` a good name? The alias is optional, so perhaps just `Count()` might be enough?
3. Alternatively, aren't aggregates really an extension of `Select()`? So perhaps it should be `SelectCount()`? Naming is hard :(

--> Voted for SelectCount()
--> Leave AsCount() removal as question for SqlKata maintainers. 

### Note
There is some preexisting existing support for the `as` keyword in SQLKata, where a lower-case `as` in a column name is treated as the 'AS' keyword, but this is fragile. This PR leaves this existing support intact. The existing `as` support does not work properly for aggregates, as in the following example.
```
Query().AsCount(new[] { "Column as Alias" }).From("Table");
--> "SELECT COUNT([Column] AS [Alias]) AS [count] FROM [Table]"
```
This yields invalid SQL syntax where there is an additional `as` added within the `count()` function.
