### PR TITLE
[DNA-567] Enable multiple aggregates per query in SqlKata.

### DIFF
--- a/QueryBuilder.Tests/AggregateTests.cs
+++ b/QueryBuilder.Tests/AggregateTests.cs
@@ -107,6 +107,57 @@ namespace SqlKata.Tests
         }
 
         [Fact]
+        public void AggregatesCanHaveALimit()
+        {
+            var query = new Query()
+                .SelectMin("ColumnA", "MinValue")
+                .SelectMax("ColumnB", "MaxValue")
+                .From("Table")
+                .Limit(100)
+                ;
+
+            var c = Compile(query);
+
+            Assert.Equal("SELECT TOP (100) MIN([ColumnA]) AS [MinValue], MAX([ColumnB]) AS [MaxValue] FROM [Table]", c[EngineCodes.SqlServer]);
+            Assert.Equal("SELECT FIRST 100 MIN(\"COLUMNA\") AS \"MINVALUE\", MAX(\"COLUMNB\") AS \"MAXVALUE\" FROM \"TABLE\"", c[EngineCodes.Firebird]);
+            Assert.Equal("SELECT MIN(`ColumnA`) AS `MinValue`, MAX(`ColumnB`) AS `MaxValue` FROM `Table` LIMIT 100", c[EngineCodes.MySql]);
+        }
+
+        [Fact]
+        public void AggregatesCanHaveAnOrderBy()
+        {
+            var query = new Query()
+                .SelectMin("ColumnA", "MinValue")
+                .SelectMax("ColumnB", "MaxValue")
+                .From("Table")
+                .OrderBy("MinValue")
+                ;
+
+            var c = Compile(query);
+
+            Assert.Equal("SELECT MIN([ColumnA]) AS [MinValue], MAX([ColumnB]) AS [MaxValue] FROM [Table] ORDER BY [MinValue]", c[EngineCodes.SqlServer]);
+            Assert.Equal("SELECT MIN(\"COLUMNA\") AS \"MINVALUE\", MAX(\"COLUMNB\") AS \"MAXVALUE\" FROM \"TABLE\" ORDER BY \"MINVALUE\"", c[EngineCodes.Firebird]);
+            Assert.Equal("SELECT MIN(`ColumnA`) AS `MinValue`, MAX(`ColumnB`) AS `MaxValue` FROM `Table` ORDER BY `MinValue`", c[EngineCodes.MySql]);
+        }
+
+        [Fact]
+        public void AggregatesCanHaveAGroupBy()
+        {
+            var query = new Query()
+                .SelectMin("ColumnA", "MinValue")
+                .SelectMax("ColumnB", "MaxValue")
+                .From("Table")
+                .GroupBy("MinValue")
+                ;
+
+            var c = Compile(query);
+
+            Assert.Equal("SELECT MIN([ColumnA]) AS [MinValue], MAX([ColumnB]) AS [MaxValue] FROM [Table] GROUP BY [MinValue]", c[EngineCodes.SqlServer]);
+            Assert.Equal("SELECT MIN(\"COLUMNA\") AS \"MINVALUE\", MAX(\"COLUMNB\") AS \"MAXVALUE\" FROM \"TABLE\" GROUP BY \"MINVALUE\"", c[EngineCodes.Firebird]);
+            Assert.Equal("SELECT MIN(`ColumnA`) AS `MinValue`, MAX(`ColumnB`) AS `MaxValue` FROM `Table` GROUP BY `MinValue`", c[EngineCodes.MySql]);
+        }
+
+        [Fact]
         public void SelectCount()
         {
             var query = new Query("A").SelectCount();

--- a/QueryBuilder.Tests/AggregateTests.cs
+++ b/QueryBuilder.Tests/AggregateTests.cs
@@ -274,6 +274,27 @@ namespace SqlKata.Tests
         }
 
         [Fact]
+        public void DistinctCountDistinctMultipleCounts()
+        {
+            // Cannot add more than one top-level aggregate clause:
+            // Because the query itself is SELECT DISTINCT, a COUNT() will
+            // be compiled to a sub-query (see DistinctCountDistinct() test).
+            // This can only be done once, as we would need to generate multiple
+            // sub-queries other wise.
+            // Idea: this might still be possible to emulate in some cases (i.e.
+            // when not already having a JOIN using several WITH clauses which
+            // SELECT ROW_NUMBER based on the conditions from the original
+            // query).
+            Assert.Throws<InvalidOperationException>(() =>
+                new Query()
+                    .Distinct()
+                    .SelectCountDistinct("ColumnA")
+                    .SelectCountDistinct("ColumnB")
+                    .From("Table")
+            );
+        }
+
+        [Fact]
         public void DistinctCountMultipleColumns()
         {
             var query = new Query("A").Distinct().SelectCount(new[] { "ColumnA", "ColumnB" });

--- a/QueryBuilder.Tests/AggregateTests.cs
+++ b/QueryBuilder.Tests/AggregateTests.cs
@@ -56,6 +56,57 @@ namespace SqlKata.Tests
         }
 
         [Fact]
+        public void MultipleAggregatesPerQuery()
+        {
+            var query = new Query()
+                .SelectMin("MinColumn")
+                .SelectMax("MaxColumn")
+                .From("Table")
+                ;
+
+            var c = Compile(query);
+
+            Assert.Equal("SELECT MIN([MinColumn]) AS [min], MAX([MaxColumn]) AS [max] FROM [Table]", c[EngineCodes.SqlServer]);
+            Assert.Equal("SELECT MIN(`MinColumn`) AS `min`, MAX(`MaxColumn`) AS `max` FROM `Table`", c[EngineCodes.MySql]);
+            Assert.Equal("SELECT MIN(\"MINCOLUMN\") AS \"MIN\", MAX(\"MAXCOLUMN\") AS \"MAX\" FROM \"TABLE\"", c[EngineCodes.Firebird]);
+            Assert.Equal("SELECT MIN(\"MinColumn\") AS \"min\", MAX(\"MaxColumn\") AS \"max\" FROM \"Table\"", c[EngineCodes.PostgreSql]);
+        }
+
+        [Fact]
+        public void AggregatesAndNonAggregatesCanBeMixedInQueries1()
+        {
+            var query = new Query()
+                .Select("ColumnA")
+                .SelectMax("ColumnB")
+                .From("Table")
+                ;
+
+            var c = Compile(query);
+
+            Assert.Equal("SELECT [ColumnA], MAX([ColumnB]) AS [max] FROM [Table]", c[EngineCodes.SqlServer]);
+            Assert.Equal("SELECT `ColumnA`, MAX(`ColumnB`) AS `max` FROM `Table`", c[EngineCodes.MySql]);
+            Assert.Equal("SELECT \"COLUMNA\", MAX(\"COLUMNB\") AS \"MAX\" FROM \"TABLE\"", c[EngineCodes.Firebird]);
+            Assert.Equal("SELECT \"ColumnA\", MAX(\"ColumnB\") AS \"max\" FROM \"Table\"", c[EngineCodes.PostgreSql]);
+        }
+
+        [Fact]
+        public void AggregatesAndNonAggregatesCanBeMixedInQueries2()
+        {
+            var query = new Query()
+                .SelectMax("ColumnA")
+                .Select("ColumnB")
+                .From("Table")
+                ;
+
+            var c = Compile(query);
+
+            Assert.Equal("SELECT MAX([ColumnA]) AS [max], [ColumnB] FROM [Table]", c[EngineCodes.SqlServer]);
+            Assert.Equal("SELECT MAX(`ColumnA`) AS `max`, `ColumnB` FROM `Table`", c[EngineCodes.MySql]);
+            Assert.Equal("SELECT MAX(\"COLUMNA\") AS \"MAX\", \"COLUMNB\" FROM \"TABLE\"", c[EngineCodes.Firebird]);
+            Assert.Equal("SELECT MAX(\"ColumnA\") AS \"max\", \"ColumnB\" FROM \"Table\"", c[EngineCodes.PostgreSql]);
+        }
+
+        [Fact]
         public void SelectCount()
         {
             var query = new Query("A").SelectCount();

--- a/QueryBuilder.Tests/AggregateTests.cs
+++ b/QueryBuilder.Tests/AggregateTests.cs
@@ -42,27 +42,17 @@ namespace SqlKata.Tests
         [Fact]
         public void SelectAggregateMultipleColumns()
         {
-            var query = new Query("A").SelectAggregate("aggregate", new[] { "Column1", "Column2" });
-
-            var c = Compile(query);
-
-            Assert.Equal("SELECT AGGREGATE(*) AS [aggregate] FROM (SELECT 1 FROM [A] WHERE [Column1] IS NOT NULL AND [Column2] IS NOT NULL) AS [AggregateQuery]", c[EngineCodes.SqlServer]);
-            Assert.Equal("SELECT AGGREGATE(*) AS `aggregate` FROM (SELECT 1 FROM `A` WHERE `Column1` IS NOT NULL AND `Column2` IS NOT NULL) AS `AggregateQuery`", c[EngineCodes.MySql]);
-            Assert.Equal("SELECT AGGREGATE(*) AS \"AGGREGATE\" FROM (SELECT 1 FROM \"A\" WHERE \"COLUMN1\" IS NOT NULL AND \"COLUMN2\" IS NOT NULL) AS \"AGGREGATEQUERY\"", c[EngineCodes.Firebird]);
-            Assert.Equal("SELECT AGGREGATE(*) AS \"aggregate\" FROM (SELECT 1 FROM \"A\" WHERE \"Column1\" IS NOT NULL AND \"Column2\" IS NOT NULL) AS \"AggregateQuery\"", c[EngineCodes.PostgreSql]);
+            Assert.Throws<ArgumentException>(() =>
+                new Query("A").SelectAggregate("aggregate", new[] { "Column1", "Column2" })
+            );
         }
 
         [Fact]
         public void SelectAggregateMultipleColumnsAlias()
         {
-            var query = new Query("A").SelectAggregate("aggregate", new[] { "Column1", "Column2" }, "Alias");
-
-            var c = Compile(query);
-
-            Assert.Equal("SELECT AGGREGATE(*) AS [Alias] FROM (SELECT 1 FROM [A] WHERE [Column1] IS NOT NULL AND [Column2] IS NOT NULL) AS [AliasAggregateQuery]", c[EngineCodes.SqlServer]);
-            Assert.Equal("SELECT AGGREGATE(*) AS `Alias` FROM (SELECT 1 FROM `A` WHERE `Column1` IS NOT NULL AND `Column2` IS NOT NULL) AS `AliasAggregateQuery`", c[EngineCodes.MySql]);
-            Assert.Equal("SELECT AGGREGATE(*) AS \"ALIAS\" FROM (SELECT 1 FROM \"A\" WHERE \"COLUMN1\" IS NOT NULL AND \"COLUMN2\" IS NOT NULL) AS \"ALIASAGGREGATEQUERY\"", c[EngineCodes.Firebird]);
-            Assert.Equal("SELECT AGGREGATE(*) AS \"Alias\" FROM (SELECT 1 FROM \"A\" WHERE \"Column1\" IS NOT NULL AND \"Column2\" IS NOT NULL) AS \"AliasAggregateQuery\"", c[EngineCodes.PostgreSql]);
+            Assert.Throws<ArgumentException>(() =>
+                new Query("A").SelectAggregate("aggregate", new[] { "Column1", "Column2" }, "Alias")
+            );
         }
 
         [Fact]

--- a/QueryBuilder/Clauses/ColumnClause.cs
+++ b/QueryBuilder/Clauses/ColumnClause.cs
@@ -63,7 +63,7 @@ namespace SqlKata
     public class AggregateColumn : AbstractColumn
     {
         public string Type { get; set; } // Min, Max, etc.
-        public List<string> Columns { get; set; } // Count can do multiple (?)
+        public string Column { get; set; } // Aggregate functions accept only a single 'value expression' (for now we implement only column name)
         public enum AggregateDistinct
         {
             aggregateNonDistinct,
@@ -79,7 +79,7 @@ namespace SqlKata
                 Component = Component,
                 Alias = Alias,
                 Type = Type,
-                Columns = Columns,
+                Column = Column,
                 Distinct = Distinct,
             };
         }

--- a/QueryBuilder/Clauses/ColumnClause.cs
+++ b/QueryBuilder/Clauses/ColumnClause.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Diagnostics;
 
 namespace SqlKata
@@ -55,6 +56,23 @@ namespace SqlKata
                 Query = Query.Clone(),
                 Component = Component,
                 Alias = Alias,
+            };
+        }
+    }
+
+    public class AggregateColumn : AbstractColumn
+    {
+        public string Type { get; set; } // Min, Max, etc.
+        public List<string> Columns { get; set; } // Count can do multiple (?)
+        public override AbstractClause Clone()
+        {
+            return new AggregateColumn
+            {
+                Engine = Engine,
+                Component = Component,
+                Alias = Alias,
+                Type = Type,
+                Columns = Columns,
             };
         }
     }

--- a/QueryBuilder/Clauses/ColumnClause.cs
+++ b/QueryBuilder/Clauses/ColumnClause.cs
@@ -64,6 +64,13 @@ namespace SqlKata
     {
         public string Type { get; set; } // Min, Max, etc.
         public List<string> Columns { get; set; } // Count can do multiple (?)
+        public enum AggregateDistinct
+        {
+            aggregateNonDistinct,
+            aggregateDistinct,
+        };
+        public AggregateDistinct Distinct { get; set; }
+        public bool IsDistinct { get { return this.Distinct == AggregateDistinct.aggregateDistinct; } }
         public override AbstractClause Clone()
         {
             return new AggregateColumn
@@ -73,6 +80,7 @@ namespace SqlKata
                 Alias = Alias,
                 Type = Type,
                 Columns = Columns,
+                Distinct = Distinct,
             };
         }
     }

--- a/QueryBuilder/Compilers/Compiler.cs
+++ b/QueryBuilder/Compilers/Compiler.cs
@@ -14,6 +14,7 @@ namespace SqlKata.Compilers
         protected virtual string OpeningIdentifier { get; set; } = "\"";
         protected virtual string ClosingIdentifier { get; set; } = "\"";
         protected virtual string ColumnAsKeyword { get; set; } = "AS ";
+        protected virtual string DistinctKeyword { get; set; } = "DISTINCT ";
         protected virtual string TableAsKeyword { get; set; } = "AS ";
         protected virtual string LastId { get; set; } = "";
         protected virtual string EscapeCharacter { get; set; } = "\\";
@@ -511,7 +512,7 @@ namespace SqlKata.Compilers
 
                     if (ctx.Query.IsDistinct)
                     {
-                        sql = "DISTINCT " + sql;
+                        sql = $"{DistinctKeyword}{sql}";
                     }
 
                     return $"SELECT {aggregate.Type.ToUpperInvariant()}({sql}) {ColumnAsKeyword}{WrapValue(aggregate.Alias ?? aggregate.Type)}";
@@ -528,7 +529,7 @@ namespace SqlKata.Compilers
                 .Select(x => CompileColumn(ctx, x))
                 .ToList();
 
-            var distinct = ctx.Query.IsDistinct ? "DISTINCT " : "";
+            var distinct = ctx.Query.IsDistinct ? DistinctKeyword : "";
 
             var select = columns.Any() ? string.Join(", ", columns) : "*";
 

--- a/QueryBuilder/Compilers/Compiler.cs
+++ b/QueryBuilder/Compilers/Compiler.cs
@@ -455,12 +455,7 @@ namespace SqlKata.Compilers
 
             if (column is AggregateColumn aggregate)
             {
-                var columns = string.Join(
-                    ", ",
-                    aggregate.Columns
-                       .Select(x => CompileColumn(ctx, new Column { Name = x }))
-                );
-                return $"{aggregate.Type.ToUpperInvariant()}({(aggregate.IsDistinct ? DistinctKeyword : "")}{columns}) {ColumnAsKeyword}{WrapValue(aggregate.Alias ?? aggregate.Type)}";
+                return $"{aggregate.Type.ToUpperInvariant()}({(aggregate.IsDistinct ? DistinctKeyword : "")}{CompileColumn(ctx, new Column { Name = aggregate.Column })}) {ColumnAsKeyword}{WrapValue(aggregate.Alias ?? aggregate.Type)}";
             }
 
             if (!string.IsNullOrWhiteSpace(column.Alias))

--- a/QueryBuilder/Compilers/Compiler.cs
+++ b/QueryBuilder/Compilers/Compiler.cs
@@ -460,7 +460,7 @@ namespace SqlKata.Compilers
                     aggregate.Columns
                        .Select(x => CompileColumn(ctx, new Column { Name = x }))
                 );
-                return $"{aggregate.Type.ToUpperInvariant()}({columns}) {ColumnAsKeyword}{WrapValue(aggregate.Alias ?? aggregate.Type)}";
+                return $"{aggregate.Type.ToUpperInvariant()}({(aggregate.IsDistinct ? DistinctKeyword : "")}{columns}) {ColumnAsKeyword}{WrapValue(aggregate.Alias ?? aggregate.Type)}";
             }
 
             if (!string.IsNullOrWhiteSpace(column.Alias))

--- a/QueryBuilder/Compilers/Compiler.cs
+++ b/QueryBuilder/Compilers/Compiler.cs
@@ -453,6 +453,16 @@ namespace SqlKata.Compilers
                 return "(" + subCtx.RawSql + $"){alias}";
             }
 
+            if (column is AggregateColumn aggregate)
+            {
+                var columns = string.Join(
+                    ", ",
+                    aggregate.Columns
+                       .Select(x => CompileColumn(ctx, new Column { Name = x }))
+                );
+                return $"{aggregate.Type.ToUpperInvariant()}({columns}) {ColumnAsKeyword}{WrapValue(aggregate.Alias ?? aggregate.Type)}";
+            }
+
             if (!string.IsNullOrWhiteSpace(column.Alias))
             {
                 return $"{Wrap((column as Column).Name)} {ColumnAsKeyword}{Wrap(column.Alias)}";

--- a/QueryBuilder/Query.Aggregate.cs
+++ b/QueryBuilder/Query.Aggregate.cs
@@ -24,19 +24,30 @@ namespace SqlKata
                 throw new System.ArgumentException("Cannot aggregate more than one column at once");
             }
 
-            Method = "aggregate";
-
-            if (this.HasComponent("aggregate"))
+            if (type != "count" || (columns.Count() == 1 && !this.IsDistinct))
             {
-                throw new System.InvalidOperationException("Cannot add more than one aggregate");
+                Method = "select";
+                this.AddComponent("select", new AggregateColumn
+                {
+                    Alias = alias,
+                    Type = type,
+                    Columns = columns.ToList(),
+                });
             }
-
-            this.AddComponent("aggregate", new AggregateClause
+            else
             {
-                Type = type,
-                Columns = columns.ToList(),
-                Alias = alias
-            });
+                if (this.HasComponent("aggregate"))
+                {
+                    throw new System.InvalidOperationException("Cannot add more than one top-level aggregate clause");
+                }
+                Method = "aggregate";
+                this.AddComponent("aggregate", new AggregateClause
+                {
+                    Alias = alias,
+                    Type = type,
+                    Columns = columns.ToList(),
+                });
+            }
 
             return this;
         }

--- a/QueryBuilder/Query.Aggregate.cs
+++ b/QueryBuilder/Query.Aggregate.cs
@@ -31,7 +31,7 @@ namespace SqlKata
                 {
                     Alias = alias,
                     Type = type,
-                    Columns = columns.ToList(),
+                    Column = columns.First(),
                     Distinct = distinct,
                 });
             }

--- a/QueryBuilder/Query.Aggregate.cs
+++ b/QueryBuilder/Query.Aggregate.cs
@@ -8,7 +8,7 @@ namespace SqlKata
         /**********************************************************************
          ** Generic aggregate                                                **
          **********************************************************************/
-        public Query SelectAggregate(string type, IEnumerable<string> columns, string alias = null)
+        public Query SelectAggregate(string type, IEnumerable<string> columns, AggregateColumn.AggregateDistinct distinct, string alias = null)
         {
             if (columns.Count() == 0)
             {
@@ -32,6 +32,7 @@ namespace SqlKata
                     Alias = alias,
                     Type = type,
                     Columns = columns.ToList(),
+                    Distinct = distinct,
                 });
             }
             else
@@ -39,6 +40,10 @@ namespace SqlKata
                 if (this.HasComponent("aggregate"))
                 {
                     throw new System.InvalidOperationException("Cannot add more than one top-level aggregate clause");
+                }
+                if (columns.Count() > 1 && distinct == AggregateColumn.AggregateDistinct.aggregateDistinct)
+                {
+                    throw new System.NotImplementedException("Count distinct over multiple columns is not implemented");
                 }
                 Method = "aggregate";
                 this.AddComponent("aggregate", new AggregateClause
@@ -61,9 +66,19 @@ namespace SqlKata
             return SelectCount(column != null ? new[] { column } : new string[] { }, alias);
         }
 
+        public Query SelectCountDistinct(string column = null, string alias = null)
+        {
+            return SelectCountDistinct(column != null ? new[] { column } : new string[] { }, alias);
+        }
+
         public Query SelectCount(IEnumerable<string> columns, string alias = null)
         {
-            return SelectAggregate("count", columns.Count() == 0 ? new[] { "*" } : columns, alias);
+            return SelectAggregate("count", columns.Count() == 0 ? new[] { "*" } : columns, AggregateColumn.AggregateDistinct.aggregateNonDistinct, alias);
+        }
+
+        public Query SelectCountDistinct(IEnumerable<string> columns, string alias = null)
+        {
+            return SelectAggregate("count", columns.Count() == 0 ? new[] { "*" } : columns, AggregateColumn.AggregateDistinct.aggregateDistinct, alias);
         }
 
 
@@ -72,10 +87,20 @@ namespace SqlKata
          **********************************************************************/
         public Query SelectAvg(string column, string alias = null)
         {
-            return SelectAggregate("avg", new[] { column }, alias);
+            return SelectAggregate("avg", new[] { column }, AggregateColumn.AggregateDistinct.aggregateNonDistinct, alias);
+        }
+
+        public Query SelectAvgDistinct(string column, string alias = null)
+        {
+            return SelectAggregate("avg", new[] { column }, AggregateColumn.AggregateDistinct.aggregateDistinct, alias);
         }
 
         public Query SelectAverage(string column, string alias = null)
+        {
+            return SelectAvg(column, alias);
+        }
+
+        public Query SelectAverageDistinct(string column, string alias = null)
         {
             return SelectAvg(column, alias);
         }
@@ -86,7 +111,12 @@ namespace SqlKata
          **********************************************************************/
         public Query SelectSum(string column, string alias = null)
         {
-            return SelectAggregate("sum", new[] { column }, alias);
+            return SelectAggregate("sum", new[] { column }, AggregateColumn.AggregateDistinct.aggregateNonDistinct, alias);
+        }
+
+        public Query SelectSumDistinct(string column, string alias = null)
+        {
+            return SelectAggregate("sum", new[] { column }, AggregateColumn.AggregateDistinct.aggregateDistinct, alias);
         }
 
 
@@ -95,7 +125,12 @@ namespace SqlKata
          **********************************************************************/
         public Query SelectMax(string column, string alias = null)
         {
-            return SelectAggregate("max", new[] { column }, alias);
+            return SelectAggregate("max", new[] { column }, AggregateColumn.AggregateDistinct.aggregateNonDistinct, alias);
+        }
+
+        public Query SelectMaxDistinct(string column, string alias = null)
+        {
+            return SelectAggregate("max", new[] { column }, AggregateColumn.AggregateDistinct.aggregateDistinct, alias);
         }
 
 
@@ -104,7 +139,12 @@ namespace SqlKata
          **********************************************************************/
         public Query SelectMin(string column, string alias = null)
         {
-            return SelectAggregate("min", new[] { column }, alias);
+            return SelectAggregate("min", new[] { column }, AggregateColumn.AggregateDistinct.aggregateNonDistinct, alias);
+        }
+
+        public Query SelectMinDistinct(string column, string alias = null)
+        {
+            return SelectAggregate("min", new[] { column }, AggregateColumn.AggregateDistinct.aggregateDistinct, alias);
         }
     }
 }

--- a/QueryBuilder/Query.Aggregate.cs
+++ b/QueryBuilder/Query.Aggregate.cs
@@ -17,8 +17,12 @@ namespace SqlKata
 
             Method = "aggregate";
 
-            this.ClearComponent("aggregate")
-            .AddComponent("aggregate", new AggregateClause
+            if (this.HasComponent("aggregate"))
+            {
+                throw new System.InvalidOperationException("Cannot add more than one aggregate");
+            }
+
+            this.AddComponent("aggregate", new AggregateClause
             {
                 Type = type,
                 Columns = columns.ToList(),

--- a/QueryBuilder/Query.Aggregate.cs
+++ b/QueryBuilder/Query.Aggregate.cs
@@ -15,6 +15,15 @@ namespace SqlKata
                 throw new System.ArgumentException("Cannot aggregate without columns");
             }
 
+            // According to ISO/IEC 9075:2016 all aggregates take only a single
+            // value expression argument (i.e. one column). However, for the
+            // special case of count(...), SqlKata implements a transform to
+            // a sub query.
+            if (columns.Count() > 1 && type != "count")
+            {
+                throw new System.ArgumentException("Cannot aggregate more than one column at once");
+            }
+
             Method = "aggregate";
 
             if (this.HasComponent("aggregate"))

--- a/SqlKata.Execution/Query.Extensions.cs
+++ b/SqlKata.Execution/Query.Extensions.cs
@@ -253,13 +253,13 @@ namespace SqlKata.Execution
         {
             var db = CreateQueryFactory(query);
 
-            return db.ExecuteScalar<T>(query.SelectAggregate(aggregateOperation, columns), transaction, timeout);
+            return db.ExecuteScalar<T>(query.SelectAggregate(aggregateOperation, columns, AggregateColumn.AggregateDistinct.aggregateNonDistinct), transaction, timeout);
         }
 
         public static async Task<T> SelectAggregateAsync<T>(this Query query, string aggregateOperation, string[] columns, IDbTransaction transaction = null, int? timeout = null)
         {
             var db = CreateQueryFactory(query);
-            return await db.ExecuteScalarAsync<T>(query.SelectAggregate(aggregateOperation, columns), transaction, timeout);
+            return await db.ExecuteScalarAsync<T>(query.SelectAggregate(aggregateOperation, columns, AggregateColumn.AggregateDistinct.aggregateNonDistinct), transaction, timeout);
         }
 
         public static T Count<T>(this Query query, string[] columns = null, IDbTransaction transaction = null, int? timeout = null)

--- a/SqlKata.Execution/QueryFactory.cs
+++ b/SqlKata.Execution/QueryFactory.cs
@@ -369,7 +369,7 @@ namespace SqlKata.Execution
             int? timeout = null
         )
         {
-            return this.ExecuteScalar<T>(query.SelectAggregate(aggregateOperation, columns), transaction, timeout ?? this.QueryTimeout);
+            return this.ExecuteScalar<T>(query.SelectAggregate(aggregateOperation, columns, AggregateColumn.AggregateDistinct.aggregateNonDistinct), transaction, timeout ?? this.QueryTimeout);
         }
 
         public async Task<T> SelectAggregateAsync<T>(
@@ -381,7 +381,7 @@ namespace SqlKata.Execution
         )
         {
             return await this.ExecuteScalarAsync<T>(
-                query.SelectAggregate(aggregateOperation, columns),
+                query.SelectAggregate(aggregateOperation, columns, AggregateColumn.AggregateDistinct.aggregateNonDistinct),
                 transaction,
                 timeout
             );


### PR DESCRIPTION
#### From Jira issue [DNA-567](https://uipath.atlassian.net/browse/DNA-567):
> Click to add description

Follows on from #5 

With this we can replace the following ...
```
                var arg = AttrNameRaw(m.Argument);
                resultQuery.SelectRaw(m.Aggregation switch
                { // TODO: DNA-84 extend SqlKata so we don't need to use SelectRaw
                    AggregationFunction.Average => $"AVG({arg}) as [{id}]",
                    AggregationFunction.Sum => $"SUM({arg}) as [{id}]",
                    AggregationFunction.Count => $"COUNT({arg}) as [{id}]",
                    AggregationFunction.CountDistinct => $"COUNT(DISTINCT {arg}) as [{id}]",
                    AggregationFunction.CaseAverage => $"SUM({arg})/COUNT(DISTINCT {AttrNameRaw(caseIdField)}) as [{id}]",
                    AggregationFunction.Max => $"MAX({arg}) as [{id}]",
                    AggregationFunction.Min => $"MIN({arg}) as [{id}]",
                    AggregationFunction.Any => $"ANY_VALUE({arg}) as [{id}]",
                    AggregationFunction.Percentage when m.Argument.Kind != FieldKind.Boolean =>
                        throw new BadDataRequestException($"aggregation method {m.Aggregation} requires {arg} to be boolean."),
                    AggregationFunction.Percentage => $"AVG(CAST({arg} AS INTEGER)) as [{id}]",
                    AggregationFunction.Percentile => $"APPROX_PERCENTILE({arg},{m.Percentile}) as [{id}]",
                    _ => throw new BadDataRequestException($"Unknown aggregation function {m.Aggregation}"),
                });
```
... with ...
```

                var arg = m.Argument.Fqn;
                var rarg = m.Argument.RawFqn;
                switch (m.Aggregation) {
                    case   AggregationFunction.Max                                                  : { resultQuery.MaxAs          (arg, $"{Attribute.IdPrefix}{id}");                                           }; break;
                    case   AggregationFunction.Min                                                  : { resultQuery.MinAs          (arg, $"{Attribute.IdPrefix}{id}");                                           }; break;
                    case   AggregationFunction.Average                                              : { resultQuery.AvgAs          (arg, $"{Attribute.IdPrefix}{id}");                                           }; break;
                    case   AggregationFunction.Sum                                                  : { resultQuery.SumAs          (arg, $"{Attribute.IdPrefix}{id}");                                           }; break;
                    case   AggregationFunction.Count                                                : { resultQuery.CountAs        (arg, $"{Attribute.IdPrefix}{id}");                                           }; break;
                    case   AggregationFunction.CountDistinct                                        : { resultQuery.CountDistinctAs(arg, $"{Attribute.IdPrefix}{id}");                                           }; break;
                    // TODO: DNA-84 extend SqlKata so we don't need to use SelectRaw
                    case   AggregationFunction.Any                                                  : { resultQuery.SelectRaw($"ANY_VALUE({rarg}) as [{Attribute.IdPrefix}{id}]");                               }; break;
                    case   AggregationFunction.Percentile                                           : { resultQuery.SelectRaw($"APPROX_PERCENTILE({rarg},{m.Percentile}) as [{Attribute.IdPrefix}{id}]");        }; break;
                    case   AggregationFunction.CaseAverage                                          : { resultQuery.SelectRaw($"SUM({rarg})/COUNT(DISTINCT {caseIdField.RawFqn}) as [{Attribute.IdPrefix}{id}]");}; break;
                    case   AggregationFunction.Percentage when m.Argument.Kind != FieldKind.Boolean : { throw new BadDataRequestException($"aggregation method {m.Aggregation} requires {rarg} to be boolean."); };
                    case   AggregationFunction.Percentage                                           : { resultQuery.SelectRaw($"AVG(CAST({rarg} AS INTEGER)) as [{Attribute.IdPrefix}{id}]");                    }; break;
                    default                                                                         : { throw new BadDataRequestException($"Unknown aggregation function {m.Aggregation}");                      };
                }
```

The remaining `SelectRaw()`s require further consideration.