### PR TITLE
Merge upstream master

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Set env
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+      - name: Checking release
+        run: |
+          echo $RELEASE_VERSION
+          echo ${{ env.RELEASE_VERSION }}
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1
         with:
@@ -94,7 +100,7 @@ jobs:
           echo Version: $VERSION
           VERSION="${VERSION//v}"
           echo Clean Version: $VERSION
-          dotnet pack -v normal -c Release --include-symbols --include-source -p:PackageVersion=$VERSION -o nupkg QueryBuilder/QueryBuilder.csproj
+          dotnet pack -v normal -c Release --include-symbols --include-source -p:Version=$VERSION -p:PackageVersion=$VERSION -o nupkg QueryBuilder/QueryBuilder.csproj
       - name: Create Release NuGet package (SqlKata.Execution)
         run: |
           arrTag=(${GITHUB_REF//\// })
@@ -102,7 +108,7 @@ jobs:
           echo Version: $VERSION
           VERSION="${VERSION//v}"
           echo Clean Version: $VERSION
-          dotnet pack -v normal -c Release --include-symbols --include-source -p:PackageVersion=$VERSION -o nupkg SqlKata.Execution/SqlKata.Execution.csproj
+          dotnet pack -v normal -c Release --include-symbols --include-source -p:Version=$VERSION -p:PackageVersion=$VERSION -o nupkg SqlKata.Execution/SqlKata.Execution.csproj
       - name: Push to GitHub Feed
         run: dotnet nuget push ./nupkg/*.nupkg --skip-duplicate --source $GITHUB_FEED --api-key $GITHUB_TOKEN
       - name: Push to NuGet Feed

--- a/QueryBuilder.Tests/GeneralTests.cs
+++ b/QueryBuilder.Tests/GeneralTests.cs
@@ -401,5 +401,39 @@ namespace SqlKata.Tests
 
             Assert.Equal("SELECT * FROM [table] WHERE ([a] = 1 OR [a] = 2)", c[EngineCodes.SqlServer].ToString());
         }
+
+        [Fact]
+        public void UnsafeLiteral_Insert()
+        {
+            var query = new Query("Table").AsInsert(new
+            {
+                Count = new UnsafeLiteral("Count + 1")
+            });
+
+            var engines = new[] {
+                EngineCodes.SqlServer,
+            };
+
+            var c = Compilers.Compile(engines, query);
+
+            Assert.Equal("INSERT INTO [Table] ([Count]) VALUES (Count + 1)", c[EngineCodes.SqlServer].ToString());
+        }
+
+        [Fact]
+        public void UnsafeLiteral_Update()
+        {
+            var query = new Query("Table").AsUpdate(new
+            {
+                Count = new UnsafeLiteral("Count + 1")
+            });
+
+            var engines = new[] {
+                EngineCodes.SqlServer,
+            };
+
+            var c = Compilers.Compile(engines, query);
+
+            Assert.Equal("UPDATE [Table] SET [Count] = Count + 1", c[EngineCodes.SqlServer].ToString());
+        }
     }
 }

--- a/QueryBuilder.Tests/UpdateTests.cs
+++ b/QueryBuilder.Tests/UpdateTests.cs
@@ -283,5 +283,37 @@ namespace SqlKata.Tests
                 "UPDATE [Table] SET [Name] = 'The User', [Age] = '2018-01-01'",
                 c[EngineCodes.SqlServer]);
         }
+
+        [Fact]
+        public void IncrementUpdate()
+        {
+            var query = new Query("Table").AsIncrement("Total");
+            var c = Compile(query);
+            Assert.Equal("UPDATE [Table] SET [Total] = [Total] + 1", c[EngineCodes.SqlServer]);
+        }
+
+        [Fact]
+        public void IncrementUpdateWithValue()
+        {
+            var query = new Query("Table").AsIncrement("Total", 2);
+            var c = Compile(query);
+            Assert.Equal("UPDATE [Table] SET [Total] = [Total] + 2", c[EngineCodes.SqlServer]);
+        }
+
+        [Fact]
+        public void IncrementUpdateWithWheres()
+        {
+            var query = new Query("Table").Where("Name", "A").AsIncrement("Total", 2);
+            var c = Compile(query);
+            Assert.Equal("UPDATE [Table] SET [Total] = [Total] + 2 WHERE [Name] = 'A'", c[EngineCodes.SqlServer]);
+        }
+
+        [Fact]
+        public void DecrementUpdate()
+        {
+            var query = new Query("Table").Where("Name", "A").AsDecrement("Total", 2);
+            var c = Compile(query);
+            Assert.Equal("UPDATE [Table] SET [Total] = [Total] - 2 WHERE [Name] = 'A'", c[EngineCodes.SqlServer]);
+        }
     }
 }

--- a/QueryBuilder.Tests/WhereTests.cs
+++ b/QueryBuilder.Tests/WhereTests.cs
@@ -1,0 +1,33 @@
+using SqlKata.Compilers;
+using SqlKata.Tests.Infrastructure;
+using Xunit;
+
+namespace SqlKata.Tests
+{
+    public class WhereTests : TestSupport
+    {
+        [Fact]
+        public void GroupedWhereFilters()
+        {
+            var q = new Query("Table1")
+                .Where(q => q.Or().Where("Column1", 10).Or().Where("Column2", 20))
+                .Where("Column3", 30);
+
+            var c = Compile(q);
+
+            Assert.Equal(@"SELECT * FROM ""Table1"" WHERE (""Column1"" = 10 OR ""Column2"" = 20) AND ""Column3"" = 30", c[EngineCodes.PostgreSql]);
+        }
+
+        [Fact]
+        public void GroupedHavingFilters()
+        {
+            var q = new Query("Table1")
+                .Having(q => q.Or().HavingRaw("SUM([Column1]) = ?", 10).Or().HavingRaw("SUM([Column2]) = ?", 20))
+                .HavingRaw("SUM([Column3]) = ?", 30);
+
+            var c = Compile(q);
+
+            Assert.Equal(@"SELECT * FROM ""Table1"" HAVING (SUM(""Column1"") = 10 OR SUM(""Column2"") = 20) AND SUM(""Column3"") = 30", c[EngineCodes.PostgreSql]);
+        }
+    }
+}

--- a/QueryBuilder/Clauses/IncrementClause.cs
+++ b/QueryBuilder/Clauses/IncrementClause.cs
@@ -1,0 +1,19 @@
+namespace SqlKata
+{
+    public class IncrementClause : InsertClause
+    {
+        public string Column { get; set; }
+        public int Value { get; set; } = 1;
+
+        public override AbstractClause Clone()
+        {
+            return new IncrementClause
+            {
+                Engine = Engine,
+                Component = Component,
+                Column = Column,
+                Value = Value
+            };
+        }
+    }
+}

--- a/QueryBuilder/Compilers/Compiler.Conditions.cs
+++ b/QueryBuilder/Compilers/Compiler.Conditions.cs
@@ -170,12 +170,14 @@ namespace SqlKata.Compilers
 
         protected virtual string CompileNestedCondition<Q>(SqlResult ctx, NestedCondition<Q> x) where Q : BaseQuery<Q>
         {
-            if (!x.Query.HasComponent("where", EngineCode))
+            if (!(x.Query.HasComponent("where", EngineCode) || x.Query.HasComponent("having", EngineCode)))
             {
                 return null;
             }
 
-            var clauses = x.Query.GetComponents<AbstractCondition>("where", EngineCode);
+            var clause = x.Query.HasComponent("where", EngineCode) ? "where" : "having";
+
+            var clauses = x.Query.GetComponents<AbstractCondition>(clause, EngineCode);
 
             var sql = CompileConditions(ctx, clauses);
 

--- a/QueryBuilder/Query.Update.cs
+++ b/QueryBuilder/Query.Update.cs
@@ -54,5 +54,22 @@ namespace SqlKata
 
             return this;
         }
+
+        public Query AsIncrement(string column, int value = 1)
+        {
+            Method = "update";
+            AddOrReplaceComponent("update", new IncrementClause
+            {
+                Column = column,
+                Value = value
+            });
+
+            return this;
+        }
+
+        public Query AsDecrement(string column, int value = 1)
+        {
+            return AsIncrement(column, -value);
+        }
     }
 }

--- a/QueryBuilder/Query.cs
+++ b/QueryBuilder/Query.cs
@@ -8,10 +8,11 @@ namespace SqlKata
 {
     public partial class Query : BaseQuery<Query>
     {
+        private string comment;
+
         public bool IsDistinct { get; set; } = false;
         public string QueryAlias { get; set; }
         public string Method { get; set; } = "select";
-        public string QueryComment { get; set; }
         public List<Include> Includes = new List<Include>();
         public Dictionary<string, object> Variables = new Dictionary<string, object>();
 
@@ -24,6 +25,8 @@ namespace SqlKata
             From(table);
             Comment(comment);
         }
+
+        public string GetComment() => comment ?? "";
 
         public bool HasOffset(string engineCode = null) => GetOffset(engineCode) > 0;
 
@@ -63,9 +66,14 @@ namespace SqlKata
             return this;
         }
 
+        /// <summary>
+        /// Sets a comment for the query.
+        /// </summary>
+        /// <param name="comment">The comment.</param>
+        /// <returns></returns>
         public Query Comment(string comment)
         {
-            QueryComment = comment;
+            this.comment = comment;
             return this;
         }
 

--- a/README.md
+++ b/README.md
@@ -89,11 +89,11 @@ var books = db.Query("Books")
 ```
 
 This will include the property "Author" on each "Book"
-```json
+```jsonc
 [{
     "Id": 1,
     "PublishedAt": "2019-01-01",
-    "AuthorId": 2
+    "AuthorId": 2,
     "Author": { // <-- included property
         "Id": 2,
         "...": ""

--- a/SqlKata.Execution/PaginationResult.cs
+++ b/SqlKata.Execution/PaginationResult.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Data;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace SqlKata.Execution
@@ -71,9 +72,9 @@ namespace SqlKata.Execution
             return this.Query.Paginate<T>(Page + 1, PerPage, transaction, timeout);
         }
 
-        public async Task<PaginationResult<T>> NextAsync(IDbTransaction transaction = null, int? timeout = null)
+        public async Task<PaginationResult<T>> NextAsync(IDbTransaction transaction = null, int? timeout = null, CancellationToken cancellationToken = default)
         {
-            return await this.Query.PaginateAsync<T>(Page + 1, PerPage, transaction, timeout);
+            return await this.Query.PaginateAsync<T>(Page + 1, PerPage, transaction, timeout, cancellationToken);
         }
 
         public Query PreviousQuery()
@@ -86,9 +87,9 @@ namespace SqlKata.Execution
             return this.Query.Paginate<T>(Page - 1, PerPage, transaction, timeout);
         }
 
-        public async Task<PaginationResult<T>> PreviousAsync(IDbTransaction transaction = null, int? timeout = null)
+        public async Task<PaginationResult<T>> PreviousAsync(IDbTransaction transaction = null, int? timeout = null, CancellationToken cancellationToken = default)
         {
-            return await this.Query.PaginateAsync<T>(Page - 1, PerPage, transaction, timeout);
+            return await this.Query.PaginateAsync<T>(Page - 1, PerPage, transaction, timeout, cancellationToken);
         }
 
         public PaginationIterator<T> Each

--- a/SqlKata.Execution/Query.Extensions.cs
+++ b/SqlKata.Execution/Query.Extensions.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System;
 using System.Threading.Tasks;
 using System.Data;
+using System.Threading;
 
 namespace SqlKata.Execution
 {
@@ -12,9 +13,9 @@ namespace SqlKata.Execution
             return CreateQueryFactory(query).Exists(query, transaction, timeout);
         }
 
-        public async static Task<bool> ExistsAsync(this Query query, IDbTransaction transaction = null, int? timeout = null)
+        public async static Task<bool> ExistsAsync(this Query query, IDbTransaction transaction = null, int? timeout = null, CancellationToken cancellationToken = default)
         {
-            return await CreateQueryFactory(query).ExistsAsync(query, transaction, timeout);
+            return await CreateQueryFactory(query).ExistsAsync(query, transaction, timeout, cancellationToken);
         }
 
         public static bool NotExist(this Query query, IDbTransaction transaction = null, int? timeout = null)
@@ -22,9 +23,9 @@ namespace SqlKata.Execution
             return !CreateQueryFactory(query).Exists(query, transaction, timeout);
         }
 
-        public async static Task<bool> NotExistAsync(this Query query, IDbTransaction transaction = null, int? timeout = null)
+        public async static Task<bool> NotExistAsync(this Query query, IDbTransaction transaction = null, int? timeout = null, CancellationToken cancellationToken = default)
         {
-            return !(await CreateQueryFactory(query).ExistsAsync(query, transaction, timeout));
+            return !(await CreateQueryFactory(query).ExistsAsync(query, transaction, timeout, cancellationToken));
         }
 
         public static IEnumerable<T> Get<T>(this Query query, IDbTransaction transaction = null, int? timeout = null)
@@ -32,9 +33,9 @@ namespace SqlKata.Execution
             return CreateQueryFactory(query).Get<T>(query, transaction, timeout);
         }
 
-        public static async Task<IEnumerable<T>> GetAsync<T>(this Query query, IDbTransaction transaction = null, int? timeout = null)
+        public static async Task<IEnumerable<T>> GetAsync<T>(this Query query, IDbTransaction transaction = null, int? timeout = null, CancellationToken cancellationToken = default)
         {
-            return await CreateQueryFactory(query).GetAsync<T>(query, transaction, timeout);
+            return await CreateQueryFactory(query).GetAsync<T>(query, transaction, timeout, cancellationToken);
         }
 
         public static IEnumerable<dynamic> Get(this Query query, IDbTransaction transaction = null, int? timeout = null)
@@ -42,9 +43,9 @@ namespace SqlKata.Execution
             return query.Get<dynamic>(transaction, timeout);
         }
 
-        public static async Task<IEnumerable<dynamic>> GetAsync(this Query query, IDbTransaction transaction = null, int? timeout = null)
+        public static async Task<IEnumerable<dynamic>> GetAsync(this Query query, IDbTransaction transaction = null, int? timeout = null, CancellationToken cancellationToken = default)
         {
-            return await GetAsync<dynamic>(query, transaction, timeout);
+            return await GetAsync<dynamic>(query, transaction, timeout, cancellationToken);
         }
 
         public static T FirstOrDefault<T>(this Query query, IDbTransaction transaction = null, int? timeout = null)
@@ -52,9 +53,9 @@ namespace SqlKata.Execution
             return CreateQueryFactory(query).FirstOrDefault<T>(query, transaction, timeout);
         }
 
-        public static async Task<T> FirstOrDefaultAsync<T>(this Query query, IDbTransaction transaction = null, int? timeout = null)
+        public static async Task<T> FirstOrDefaultAsync<T>(this Query query, IDbTransaction transaction = null, int? timeout = null, CancellationToken cancellationToken = default)
         {
-            return await CreateQueryFactory(query).FirstOrDefaultAsync<T>(query, transaction, timeout);
+            return await CreateQueryFactory(query).FirstOrDefaultAsync<T>(query, transaction, timeout, cancellationToken);
         }
 
         public static dynamic FirstOrDefault(this Query query, IDbTransaction transaction = null, int? timeout = null)
@@ -62,9 +63,9 @@ namespace SqlKata.Execution
             return FirstOrDefault<dynamic>(query, transaction, timeout);
         }
 
-        public static async Task<dynamic> FirstOrDefaultAsync(this Query query, IDbTransaction transaction = null, int? timeout = null)
+        public static async Task<dynamic> FirstOrDefaultAsync(this Query query, IDbTransaction transaction = null, int? timeout = null, CancellationToken cancellationToken = default)
         {
-            return await FirstOrDefaultAsync<dynamic>(query, transaction, timeout);
+            return await FirstOrDefaultAsync<dynamic>(query, transaction, timeout, cancellationToken);
         }
 
         public static T First<T>(this Query query, IDbTransaction transaction = null, int? timeout = null)
@@ -72,9 +73,9 @@ namespace SqlKata.Execution
             return CreateQueryFactory(query).First<T>(query, transaction, timeout);
         }
 
-        public static async Task<T> FirstAsync<T>(this Query query, IDbTransaction transaction = null, int? timeout = null)
+        public static async Task<T> FirstAsync<T>(this Query query, IDbTransaction transaction = null, int? timeout = null, CancellationToken cancellationToken = default)
         {
-            return await CreateQueryFactory(query).FirstAsync<T>(query, transaction, timeout);
+            return await CreateQueryFactory(query).FirstAsync<T>(query, transaction, timeout, cancellationToken);
         }
 
         public static dynamic First(this Query query, IDbTransaction transaction = null, int? timeout = null)
@@ -82,9 +83,9 @@ namespace SqlKata.Execution
             return First<dynamic>(query, transaction, timeout);
         }
 
-        public static async Task<dynamic> FirstAsync(this Query query, IDbTransaction transaction = null, int? timeout = null)
+        public static async Task<dynamic> FirstAsync(this Query query, IDbTransaction transaction = null, int? timeout = null, CancellationToken cancellationToken = default)
         {
-            return await FirstAsync<dynamic>(query, transaction, timeout);
+            return await FirstAsync<dynamic>(query, transaction, timeout, cancellationToken);
         }
 
         public static PaginationResult<T> Paginate<T>(this Query query, int page, int perPage = 25, IDbTransaction transaction = null, int? timeout = null)
@@ -94,11 +95,11 @@ namespace SqlKata.Execution
             return db.Paginate<T>(query, page, perPage, transaction, timeout);
         }
 
-        public static async Task<PaginationResult<T>> PaginateAsync<T>(this Query query, int page, int perPage = 25, IDbTransaction transaction = null, int? timeout = null)
+        public static async Task<PaginationResult<T>> PaginateAsync<T>(this Query query, int page, int perPage = 25, IDbTransaction transaction = null, int? timeout = null, CancellationToken cancellationToken = default)
         {
             var db = CreateQueryFactory(query);
 
-            return await db.PaginateAsync<T>(query, page, perPage, transaction, timeout);
+            return await db.PaginateAsync<T>(query, page, perPage, transaction, timeout, cancellationToken);
         }
 
         public static PaginationResult<dynamic> Paginate(this Query query, int page, int perPage = 25, IDbTransaction transaction = null, int? timeout = null)
@@ -106,9 +107,9 @@ namespace SqlKata.Execution
             return query.Paginate<dynamic>(page, perPage, transaction, timeout);
         }
 
-        public static async Task<PaginationResult<dynamic>> PaginateAsync(this Query query, int page, int perPage = 25, IDbTransaction transaction = null, int? timeout = null)
+        public static async Task<PaginationResult<dynamic>> PaginateAsync(this Query query, int page, int perPage = 25, IDbTransaction transaction = null, int? timeout = null, CancellationToken cancellationToken = default)
         {
-            return await PaginateAsync<dynamic>(query, page, perPage, transaction, timeout);
+            return await PaginateAsync<dynamic>(query, page, perPage, transaction, timeout, cancellationToken);
         }
 
         public static void Chunk<T>(this Query query, int chunkSize, Func<IEnumerable<T>, int, bool> func, IDbTransaction transaction = null, int? timeout = null)
@@ -117,18 +118,18 @@ namespace SqlKata.Execution
 
             db.Chunk<T>(query, chunkSize, func, transaction, timeout);
         }
-        public static async Task ChunkAsync<T>(this Query query, int chunkSize, Func<IEnumerable<T>, int, bool> func, IDbTransaction transaction = null, int? timeout = null)
+        public static async Task ChunkAsync<T>(this Query query, int chunkSize, Func<IEnumerable<T>, int, bool> func, IDbTransaction transaction = null, int? timeout = null, CancellationToken cancellationToken = default)
         {
-            await CreateQueryFactory(query).ChunkAsync<T>(query, chunkSize, func, transaction, timeout);
+            await CreateQueryFactory(query).ChunkAsync<T>(query, chunkSize, func, transaction, timeout, cancellationToken);
         }
 
         public static void Chunk(this Query query, int chunkSize, Func<IEnumerable<dynamic>, int, bool> func, IDbTransaction transaction = null, int? timeout = null)
         {
             query.Chunk<dynamic>(chunkSize, func, transaction, timeout);
         }
-        public static async Task ChunkAsync(this Query query, int chunkSize, Func<IEnumerable<dynamic>, int, bool> func, IDbTransaction transaction = null, int? timeout = null)
+        public static async Task ChunkAsync(this Query query, int chunkSize, Func<IEnumerable<dynamic>, int, bool> func, IDbTransaction transaction = null, int? timeout = null, CancellationToken cancellationToken = default)
         {
-            await ChunkAsync<dynamic>(query, chunkSize, func, transaction, timeout);
+            await ChunkAsync<dynamic>(query, chunkSize, func, transaction, timeout, cancellationToken);
         }
 
         public static void Chunk<T>(this Query query, int chunkSize, Action<IEnumerable<T>, int> action, IDbTransaction transaction = null, int? timeout = null)
@@ -138,9 +139,9 @@ namespace SqlKata.Execution
             db.Chunk(query, chunkSize, action, transaction, timeout);
         }
 
-        public static async Task ChunkAsync<T>(this Query query, int chunkSize, Action<IEnumerable<T>, int> action, IDbTransaction transaction = null, int? timeout = null)
+        public static async Task ChunkAsync<T>(this Query query, int chunkSize, Action<IEnumerable<T>, int> action, IDbTransaction transaction = null, int? timeout = null, CancellationToken cancellationToken = default)
         {
-            await CreateQueryFactory(query).ChunkAsync<T>(query, chunkSize, action, transaction, timeout);
+            await CreateQueryFactory(query).ChunkAsync<T>(query, chunkSize, action, transaction, timeout, cancellationToken);
         }
 
         public static void Chunk(this Query query, int chunkSize, Action<IEnumerable<dynamic>, int> action, IDbTransaction transaction = null, int? timeout = null)
@@ -148,9 +149,9 @@ namespace SqlKata.Execution
             query.Chunk<dynamic>(chunkSize, action, transaction, timeout);
         }
 
-        public static async Task ChunkAsync(this Query query, int chunkSize, Action<IEnumerable<dynamic>, int> action, IDbTransaction transaction = null, int? timeout = null)
+        public static async Task ChunkAsync(this Query query, int chunkSize, Action<IEnumerable<dynamic>, int> action, IDbTransaction transaction = null, int? timeout = null, CancellationToken cancellationToken = default)
         {
-            await ChunkAsync<dynamic>(query, chunkSize, action, transaction, timeout);
+            await ChunkAsync<dynamic>(query, chunkSize, action, transaction, timeout, cancellationToken);
         }
 
         public static int Insert(this Query query, IEnumerable<KeyValuePair<string, object>> values, IDbTransaction transaction = null, int? timeout = null)
@@ -158,9 +159,9 @@ namespace SqlKata.Execution
             return CreateQueryFactory(query).Execute(query.AsInsert(values), transaction, timeout);
         }
 
-        public static async Task<int> InsertAsync(this Query query, IEnumerable<KeyValuePair<string, object>> values, IDbTransaction transaction = null, int? timeout = null)
+        public static async Task<int> InsertAsync(this Query query, IEnumerable<KeyValuePair<string, object>> values, IDbTransaction transaction = null, int? timeout = null, CancellationToken cancellationToken = default)
         {
-            return await CreateQueryFactory(query).ExecuteAsync(query.AsInsert(values), transaction, timeout);
+            return await CreateQueryFactory(query).ExecuteAsync(query.AsInsert(values), transaction, timeout, cancellationToken);
         }
 
         public static int Insert(this Query query, IEnumerable<string> columns, IEnumerable<IEnumerable<object>> valuesCollection, IDbTransaction transaction = null, int? timeout = null)
@@ -168,14 +169,19 @@ namespace SqlKata.Execution
             return CreateQueryFactory(query).Execute(query.AsInsert(columns, valuesCollection), transaction, timeout);
         }
 
+        public static async Task<int> InsertAsync(this Query query, IEnumerable<string> columns, IEnumerable<IEnumerable<object>> valuesCollection, IDbTransaction transaction = null, int? timeout = null, CancellationToken cancellationToken = default)
+        {
+            return await CreateQueryFactory(query).ExecuteAsync(query.AsInsert(columns, valuesCollection), transaction, timeout, cancellationToken);
+        }
+
         public static int Insert(this Query query, IEnumerable<string> columns, Query fromQuery, IDbTransaction transaction = null, int? timeout = null)
         {
             return CreateQueryFactory(query).Execute(query.AsInsert(columns, fromQuery), transaction, timeout);
         }
 
-        public static async Task<int> InsertAsync(this Query query, IEnumerable<string> columns, Query fromQuery, IDbTransaction transaction = null, int? timeout = null)
+        public static async Task<int> InsertAsync(this Query query, IEnumerable<string> columns, Query fromQuery, IDbTransaction transaction = null, int? timeout = null, CancellationToken cancellationToken = default)
         {
-            return await CreateQueryFactory(query).ExecuteAsync(query.AsInsert(columns, fromQuery), transaction, timeout);
+            return await CreateQueryFactory(query).ExecuteAsync(query.AsInsert(columns, fromQuery), transaction, timeout, cancellationToken);
         }
 
         public static int Insert(this Query query, object data, IDbTransaction transaction = null, int? timeout = null)
@@ -183,9 +189,9 @@ namespace SqlKata.Execution
             return CreateQueryFactory(query).Execute(query.AsInsert(data), transaction, timeout);
         }
 
-        public static async Task<int> InsertAsync(this Query query, object data, IDbTransaction transaction = null, int? timeout = null)
+        public static async Task<int> InsertAsync(this Query query, object data, IDbTransaction transaction = null, int? timeout = null, CancellationToken cancellationToken = default)
         {
-            return await CreateQueryFactory(query).ExecuteAsync(query.AsInsert(data), transaction, timeout);
+            return await CreateQueryFactory(query).ExecuteAsync(query.AsInsert(data), transaction, timeout, cancellationToken);
         }
 
         public static T InsertGetId<T>(this Query query, object data, IDbTransaction transaction = null, int? timeout = null)
@@ -197,10 +203,10 @@ namespace SqlKata.Execution
             return row.Id;
         }
 
-        public static async Task<T> InsertGetIdAsync<T>(this Query query, object data, IDbTransaction transaction = null, int? timeout = null)
+        public static async Task<T> InsertGetIdAsync<T>(this Query query, object data, IDbTransaction transaction = null, int? timeout = null, CancellationToken cancellationToken = default)
         {
             var row = await CreateQueryFactory(query)
-                .FirstAsync<InsertGetIdRow<T>>(query.AsInsert(data, true), transaction, timeout);
+                .FirstAsync<InsertGetIdRow<T>>(query.AsInsert(data, true), transaction, timeout, cancellationToken);
 
             return row.Id;
         }
@@ -212,9 +218,9 @@ namespace SqlKata.Execution
             return row.Id;
         }
 
-        public static async Task<T> InsertGetIdAsync<T>(this Query query, IEnumerable<KeyValuePair<string, object>> data, IDbTransaction transaction = null, int? timeout = null)
+        public static async Task<T> InsertGetIdAsync<T>(this Query query, IEnumerable<KeyValuePair<string, object>> data, IDbTransaction transaction = null, int? timeout = null, CancellationToken cancellationToken = default)
         {
-            var row = await CreateQueryFactory(query).FirstAsync<InsertGetIdRow<T>>(query.AsInsert(data, true), transaction, timeout);
+            var row = await CreateQueryFactory(query).FirstAsync<InsertGetIdRow<T>>(query.AsInsert(data, true), transaction, timeout, cancellationToken);
 
             return row.Id;
         }
@@ -224,9 +230,9 @@ namespace SqlKata.Execution
             return CreateQueryFactory(query).Execute(query.AsUpdate(values), transaction, timeout);
         }
 
-        public static async Task<int> UpdateAsync(this Query query, IEnumerable<KeyValuePair<string, object>> values, IDbTransaction transaction = null, int? timeout = null)
+        public static async Task<int> UpdateAsync(this Query query, IEnumerable<KeyValuePair<string, object>> values, IDbTransaction transaction = null, int? timeout = null, CancellationToken cancellationToken = default)
         {
-            return await CreateQueryFactory(query).ExecuteAsync(query.AsUpdate(values), transaction, timeout);
+            return await CreateQueryFactory(query).ExecuteAsync(query.AsUpdate(values), transaction, timeout, cancellationToken);
         }
 
         public static int Update(this Query query, object data, IDbTransaction transaction = null, int? timeout = null)
@@ -234,9 +240,29 @@ namespace SqlKata.Execution
             return CreateQueryFactory(query).Execute(query.AsUpdate(data), transaction, timeout);
         }
 
-        public static async Task<int> UpdateAsync(this Query query, object data, IDbTransaction transaction = null, int? timeout = null)
+        public static async Task<int> UpdateAsync(this Query query, object data, IDbTransaction transaction = null, int? timeout = null, CancellationToken cancellationToken = default)
         {
-            return await CreateQueryFactory(query).ExecuteAsync(query.AsUpdate(data), transaction, timeout);
+            return await CreateQueryFactory(query).ExecuteAsync(query.AsUpdate(data), transaction, timeout, cancellationToken);
+        }
+
+        public static int Increment(this Query query, string column, int value = 1, IDbTransaction transaction = null, int? timeout = null)
+        {
+            return CreateQueryFactory(query).Execute(query.AsIncrement(column, value), transaction, timeout);
+        }
+
+        public static async Task<int> IncrementAsync(this Query query, string column, int value = 1, IDbTransaction transaction = null, int? timeout = null, CancellationToken cancellationToken = default)
+        {
+            return await CreateQueryFactory(query).ExecuteAsync(query.AsIncrement(column, value), transaction, timeout, cancellationToken);
+        }
+
+        public static int Decrement(this Query query, string column, int value = 1, IDbTransaction transaction = null, int? timeout = null)
+        {
+            return CreateQueryFactory(query).Execute(query.AsDecrement(column, value), transaction, timeout);
+        }
+
+        public static async Task<int> DecrementAsync(this Query query, string column, int value = 1, IDbTransaction transaction = null, int? timeout = null, CancellationToken cancellationToken = default)
+        {
+            return await CreateQueryFactory(query).ExecuteAsync(query.AsDecrement(column, value), transaction, timeout, cancellationToken);
         }
 
         public static int Delete(this Query query, IDbTransaction transaction = null, int? timeout = null)
@@ -244,76 +270,76 @@ namespace SqlKata.Execution
             return CreateQueryFactory(query).Execute(query.AsDelete(), transaction, timeout);
         }
 
-        public static async Task<int> DeleteAsync(this Query query, IDbTransaction transaction = null, int? timeout = null)
+        public static async Task<int> DeleteAsync(this Query query, IDbTransaction transaction = null, int? timeout = null, CancellationToken cancellationToken = default)
         {
-            return await CreateQueryFactory(query).ExecuteAsync(query.AsDelete(), transaction, timeout);
+            return await CreateQueryFactory(query).ExecuteAsync(query.AsDelete(), transaction, timeout, cancellationToken);
         }
 
-        public static T Aggregate<T>(this Query query, string aggregateOperation, string[] columns, IDbTransaction transaction = null, int? timeout = null)
+        public static T SelectAggregate<T>(this Query query, string aggregateOperation, string[] columns, IDbTransaction transaction = null, int? timeout = null)
         {
             var db = CreateQueryFactory(query);
 
             return db.ExecuteScalar<T>(query.SelectAggregate(aggregateOperation, columns, AggregateColumn.AggregateDistinct.aggregateNonDistinct), transaction, timeout);
         }
 
-        public static async Task<T> SelectAggregateAsync<T>(this Query query, string aggregateOperation, string[] columns, IDbTransaction transaction = null, int? timeout = null)
+        public static async Task<T> SelectAggregateAsync<T>(this Query query, string aggregateOperation, string[] columns, IDbTransaction transaction = null, int? timeout = null, CancellationToken cancellationToken = default)
         {
             var db = CreateQueryFactory(query);
-            return await db.ExecuteScalarAsync<T>(query.SelectAggregate(aggregateOperation, columns, AggregateColumn.AggregateDistinct.aggregateNonDistinct), transaction, timeout);
+            return await db.ExecuteScalarAsync<T>(query.SelectAggregate(aggregateOperation, columns, AggregateColumn.AggregateDistinct.aggregateNonDistinct), transaction, timeout, cancellationToken);
         }
 
-        public static T Count<T>(this Query query, string[] columns = null, IDbTransaction transaction = null, int? timeout = null)
+        public static T SelectCount<T>(this Query query, string[] columns = null, IDbTransaction transaction = null, int? timeout = null)
         {
             var db = CreateQueryFactory(query);
 
             return db.ExecuteScalar<T>(query.SelectCount(columns), transaction, timeout);
         }
 
-        public static async Task<T> SelectCountAsync<T>(this Query query, string[] columns = null, IDbTransaction transaction = null, int? timeout = null)
+        public static async Task<T> SelectCountAsync<T>(this Query query, string[] columns = null, IDbTransaction transaction = null, int? timeout = null, CancellationToken cancellationToken = default)
         {
             var db = CreateQueryFactory(query);
 
-            return await db.ExecuteScalarAsync<T>(query.SelectCount(columns), transaction, timeout);
+            return await db.ExecuteScalarAsync<T>(query.SelectCount(columns), transaction, timeout, cancellationToken);
         }
 
-        public static T Average<T>(this Query query, string column, IDbTransaction transaction = null, int? timeout = null)
+        public static T SelectAverage<T>(this Query query, string column, IDbTransaction transaction = null, int? timeout = null)
         {
-            return query.Aggregate<T>("avg", new[] { column }, transaction, timeout);
+            return query.SelectAggregate<T>("avg", new[] { column }, transaction, timeout);
         }
 
-        public static async Task<T> SelectAverageAsync<T>(this Query query, string column, IDbTransaction transaction = null, int? timeout = null)
+        public static async Task<T> SelectAverageAsync<T>(this Query query, string column, IDbTransaction transaction = null, int? timeout = null, CancellationToken cancellationToken = default)
         {
-            return await query.SelectAggregateAsync<T>("avg", new[] { column }, transaction, timeout);
+            return await query.SelectAggregateAsync<T>("avg", new[] { column }, transaction, timeout, cancellationToken);
         }
 
-        public static T Sum<T>(this Query query, string column, IDbTransaction transaction = null, int? timeout = null)
+        public static T SelectSum<T>(this Query query, string column, IDbTransaction transaction = null, int? timeout = null)
         {
-            return query.Aggregate<T>("sum", new[] { column }, transaction, timeout);
+            return query.SelectAggregate<T>("sum", new[] { column }, transaction, timeout);
         }
 
-        public static async Task<T> SelectSumAsync<T>(this Query query, string column, IDbTransaction transaction = null, int? timeout = null)
+        public static async Task<T> SelectSumAsync<T>(this Query query, string column, IDbTransaction transaction = null, int? timeout = null, CancellationToken cancellationToken = default)
         {
-            return await query.SelectAggregateAsync<T>("sum", new[] { column }, transaction, timeout);
+            return await query.SelectAggregateAsync<T>("sum", new[] { column }, transaction, timeout, cancellationToken);
         }
 
-        public static T Min<T>(this Query query, string column, IDbTransaction transaction = null, int? timeout = null)
+        public static T SelectMin<T>(this Query query, string column, IDbTransaction transaction = null, int? timeout = null)
         {
-            return query.Aggregate<T>("min", new[] { column }, transaction, timeout);
+            return query.SelectAggregate<T>("min", new[] { column }, transaction, timeout);
         }
 
-        public static async Task<T> SelectMinAsync<T>(this Query query, string column, IDbTransaction transaction = null, int? timeout = null)
+        public static async Task<T> SelectMinAsync<T>(this Query query, string column, IDbTransaction transaction = null, int? timeout = null, CancellationToken cancellationToken = default)
         {
-            return await query.SelectAggregateAsync<T>("min", new[] { column }, transaction, timeout);
+            return await query.SelectAggregateAsync<T>("min", new[] { column }, transaction, timeout, cancellationToken);
         }
 
-        public static T Max<T>(this Query query, string column, IDbTransaction transaction = null, int? timeout = null)
+        public static T SelectMax<T>(this Query query, string column, IDbTransaction transaction = null, int? timeout = null)
         {
-            return query.Aggregate<T>("max", new[] { column }, transaction, timeout);
+            return query.SelectAggregate<T>("max", new[] { column }, transaction, timeout);
         }
 
-        public static async Task<T> SelectMaxAsync<T>(this Query query, string column, IDbTransaction transaction = null, int? timeout = null)
+        public static async Task<T> SelectMaxAsync<T>(this Query query, string column, IDbTransaction transaction = null, int? timeout = null, CancellationToken cancellationToken = default)
         {
-            return await query.SelectAggregateAsync<T>("max", new[] { column }, transaction, timeout);
+            return await query.SelectAggregateAsync<T>("max", new[] { column }, transaction, timeout, cancellationToken);
         }
 
         internal static XQuery CastToXQuery(Query query, string method = null)

--- a/SqlKata.Execution/QueryFactory.cs
+++ b/SqlKata.Execution/QueryFactory.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Data;
 using System.Dynamic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Dapper;
 using Humanizer;
@@ -87,18 +88,19 @@ namespace SqlKata.Execution
             return result;
         }
 
-        public async Task<IEnumerable<T>> GetAsync<T>(Query query, IDbTransaction transaction = null, int? timeout = null)
+        public async Task<IEnumerable<T>> GetAsync<T>(Query query, IDbTransaction transaction = null, int? timeout = null, CancellationToken cancellationToken = default)
         {
             var compiled = CompileAndLog(query);
-
-            var result = (await this.Connection.QueryAsync<T>(
-                compiled.Sql,
-                compiled.NamedBindings,
+            var commandDefinition = new CommandDefinition(
+                commandText: compiled.Sql,
+                parameters: compiled.NamedBindings,
                 transaction: transaction,
-                commandTimeout: timeout ?? this.QueryTimeout
-            )).ToList();
+                commandTimeout: timeout ?? this.QueryTimeout,
+                cancellationToken: cancellationToken);
 
-            result = (await handleIncludesAsync(query, result)).ToList();
+            var result = (await this.Connection.QueryAsync<T>(commandDefinition)).ToList();
+
+            result = (await handleIncludesAsync(query, result, cancellationToken)).ToList();
 
             return result;
         }
@@ -117,16 +119,17 @@ namespace SqlKata.Execution
             return result.Cast<IDictionary<string, object>>();
         }
 
-        public async Task<IEnumerable<IDictionary<string, object>>> GetDictionaryAsync(Query query, IDbTransaction transaction = null, int? timeout = null)
+        public async Task<IEnumerable<IDictionary<string, object>>> GetDictionaryAsync(Query query, IDbTransaction transaction = null, int? timeout = null, CancellationToken cancellationToken = default)
         {
             var compiled = CompileAndLog(query);
-
-            var result = await this.Connection.QueryAsync(
-                compiled.Sql,
-                compiled.NamedBindings,
+            var commandDefinition = new CommandDefinition(
+                commandText: compiled.Sql,
+                parameters: compiled.NamedBindings,
                 transaction: transaction,
-                commandTimeout: timeout ?? this.QueryTimeout
-            );
+                commandTimeout: timeout ?? this.QueryTimeout,
+                cancellationToken: cancellationToken);
+
+            var result = await this.Connection.QueryAsync(commandDefinition);
 
             return result.Cast<IDictionary<string, object>>();
         }
@@ -136,9 +139,9 @@ namespace SqlKata.Execution
             return Get<dynamic>(query, transaction, timeout);
         }
 
-        public async Task<IEnumerable<dynamic>> GetAsync(Query query, IDbTransaction transaction = null, int? timeout = null)
+        public async Task<IEnumerable<dynamic>> GetAsync(Query query, IDbTransaction transaction = null, int? timeout = null, CancellationToken cancellationToken = default)
         {
-            return await GetAsync<dynamic>(query, transaction, timeout);
+            return await GetAsync<dynamic>(query, transaction, timeout, cancellationToken);
         }
 
         public T FirstOrDefault<T>(Query query, IDbTransaction transaction = null, int? timeout = null)
@@ -148,9 +151,9 @@ namespace SqlKata.Execution
             return list.ElementAtOrDefault(0);
         }
 
-        public async Task<T> FirstOrDefaultAsync<T>(Query query, IDbTransaction transaction = null, int? timeout = null)
+        public async Task<T> FirstOrDefaultAsync<T>(Query query, IDbTransaction transaction = null, int? timeout = null, CancellationToken cancellationToken = default)
         {
-            var list = await GetAsync<T>(query.Limit(1), transaction, timeout);
+            var list = await GetAsync<T>(query.Limit(1), transaction, timeout, cancellationToken);
 
             return list.ElementAtOrDefault(0);
         }
@@ -160,9 +163,9 @@ namespace SqlKata.Execution
             return FirstOrDefault<dynamic>(query, transaction, timeout);
         }
 
-        public async Task<dynamic> FirstOrDefaultAsync(Query query, IDbTransaction transaction = null, int? timeout = null)
+        public async Task<dynamic> FirstOrDefaultAsync(Query query, IDbTransaction transaction = null, int? timeout = null, CancellationToken cancellationToken = default)
         {
-            return await FirstOrDefaultAsync<dynamic>(query, transaction, timeout);
+            return await FirstOrDefaultAsync<dynamic>(query, transaction, timeout, cancellationToken);
         }
 
         public T First<T>(Query query, IDbTransaction transaction = null, int? timeout = null)
@@ -177,9 +180,9 @@ namespace SqlKata.Execution
             return item;
         }
 
-        public async Task<T> FirstAsync<T>(Query query, IDbTransaction transaction = null, int? timeout = null)
+        public async Task<T> FirstAsync<T>(Query query, IDbTransaction transaction = null, int? timeout = null, CancellationToken cancellationToken = default)
         {
-            var item = await FirstOrDefaultAsync<T>(query, transaction, timeout);
+            var item = await FirstOrDefaultAsync<T>(query, transaction, timeout, cancellationToken);
 
             if (item == null)
             {
@@ -194,9 +197,9 @@ namespace SqlKata.Execution
             return First<dynamic>(query, transaction, timeout);
         }
 
-        public async Task<dynamic> FirstAsync(Query query, IDbTransaction transaction = null, int? timeout = null)
+        public async Task<dynamic> FirstAsync(Query query, IDbTransaction transaction = null, int? timeout = null, CancellationToken cancellationToken = default)
         {
-            return await FirstAsync<dynamic>(query, transaction, timeout);
+            return await FirstAsync<dynamic>(query, transaction, timeout, cancellationToken);
         }
 
         public int Execute(
@@ -218,17 +221,19 @@ namespace SqlKata.Execution
         public async Task<int> ExecuteAsync(
             Query query,
             IDbTransaction transaction = null,
-            int? timeout = null
+            int? timeout = null,
+            CancellationToken cancellationToken = default
         )
         {
             var compiled = CompileAndLog(query);
+            var commandDefinition = new CommandDefinition(
+                commandText: compiled.Sql,
+                parameters: compiled.NamedBindings,
+                transaction: transaction,
+                commandTimeout: timeout ?? this.QueryTimeout,
+                cancellationToken: cancellationToken);
 
-            return await this.Connection.ExecuteAsync(
-                compiled.Sql,
-                compiled.NamedBindings,
-                transaction,
-                timeout ?? this.QueryTimeout
-            );
+            return await this.Connection.ExecuteAsync(commandDefinition);
         }
 
         public T ExecuteScalar<T>(Query query, IDbTransaction transaction = null, int? timeout = null)
@@ -246,17 +251,19 @@ namespace SqlKata.Execution
         public async Task<T> ExecuteScalarAsync<T>(
             Query query,
             IDbTransaction transaction = null,
-            int? timeout = null
+            int? timeout = null,
+            CancellationToken cancellationToken = default
         )
         {
             var compiled = CompileAndLog(query.Limit(1));
+            var commandDefinition = new CommandDefinition(
+                commandText: compiled.Sql,
+                parameters: compiled.NamedBindings,
+                transaction: transaction,
+                commandTimeout: timeout ?? this.QueryTimeout,
+                cancellationToken: cancellationToken);
 
-            return await this.Connection.ExecuteScalarAsync<T>(
-                compiled.Sql,
-                compiled.NamedBindings,
-                transaction,
-                timeout ?? this.QueryTimeout
-            );
+            return await this.Connection.ExecuteScalarAsync<T>(commandDefinition);
         }
 
         public SqlMapper.GridReader GetMultiple<T>(
@@ -278,16 +285,18 @@ namespace SqlKata.Execution
         public async Task<SqlMapper.GridReader> GetMultipleAsync<T>(
             Query[] queries,
             IDbTransaction transaction = null,
-            int? timeout = null)
+            int? timeout = null,
+            CancellationToken cancellationToken = default)
         {
             var compiled = this.Compiler.Compile(queries);
+            var commandDefinition = new CommandDefinition(
+                commandText: compiled.Sql,
+                parameters: compiled.NamedBindings,
+                transaction: transaction,
+                commandTimeout: timeout ?? this.QueryTimeout,
+                cancellationToken: cancellationToken);
 
-            return await this.Connection.QueryMultipleAsync(
-                compiled.Sql,
-                compiled.NamedBindings,
-                transaction,
-                timeout ?? this.QueryTimeout
-            );
+            return await this.Connection.QueryMultipleAsync(commandDefinition);
         }
 
         public IEnumerable<IEnumerable<T>> Get<T>(
@@ -315,13 +324,15 @@ namespace SqlKata.Execution
         public async Task<IEnumerable<IEnumerable<T>>> GetAsync<T>(
             Query[] queries,
             IDbTransaction transaction = null,
-            int? timeout = null
+            int? timeout = null,
+            CancellationToken cancellationToken = default
         )
         {
             var multi = await this.GetMultipleAsync<T>(
                 queries,
                 transaction,
-                timeout
+                timeout,
+                cancellationToken
             );
 
             var list = new List<IEnumerable<T>>();
@@ -349,19 +360,19 @@ namespace SqlKata.Execution
             return rows.Any();
         }
 
-        public async Task<bool> ExistsAsync(Query query, IDbTransaction transaction = null, int? timeout = null)
+        public async Task<bool> ExistsAsync(Query query, IDbTransaction transaction = null, int? timeout = null, CancellationToken cancellationToken = default)
         {
             var clone = query.Clone()
                 .ClearComponent("select")
                 .SelectRaw("1 as [Exists]")
                 .Limit(1);
 
-            var rows = await GetAsync(clone, transaction, timeout);
+            var rows = await GetAsync(clone, transaction, timeout, cancellationToken);
 
             return rows.Any();
         }
 
-        public T Aggregate<T>(
+        public T SelectAggregate<T>(
             Query query,
             string aggregateOperation,
             string[] columns = null,
@@ -377,17 +388,19 @@ namespace SqlKata.Execution
             string aggregateOperation,
             string[] columns = null,
             IDbTransaction transaction = null,
-            int? timeout = null
+            int? timeout = null,
+            CancellationToken cancellationToken = default
         )
         {
             return await this.ExecuteScalarAsync<T>(
                 query.SelectAggregate(aggregateOperation, columns, AggregateColumn.AggregateDistinct.aggregateNonDistinct),
                 transaction,
-                timeout
+                timeout,
+                cancellationToken
             );
         }
 
-        public T Count<T>(Query query, string[] columns = null, IDbTransaction transaction = null, int? timeout = null)
+        public T SelectCount<T>(Query query, string[] columns = null, IDbTransaction transaction = null, int? timeout = null)
         {
             return this.ExecuteScalar<T>(
                 query.SelectCount(columns),
@@ -396,49 +409,49 @@ namespace SqlKata.Execution
             );
         }
 
-        public async Task<T> SelectCountAsync<T>(Query query, string[] columns = null, IDbTransaction transaction = null, int? timeout = null)
+        public async Task<T> SelectCountAsync<T>(Query query, string[] columns = null, IDbTransaction transaction = null, int? timeout = null, CancellationToken cancellationToken = default)
         {
-            return await this.ExecuteScalarAsync<T>(query.SelectCount(columns), transaction, timeout);
+            return await this.ExecuteScalarAsync<T>(query.SelectCount(columns), transaction, timeout, cancellationToken);
         }
 
-        public T Average<T>(Query query, string column, IDbTransaction transaction = null, int? timeout = null)
+        public T SelectAverage<T>(Query query, string column, IDbTransaction transaction = null, int? timeout = null)
         {
-            return this.Aggregate<T>(query, "avg", new[] { column });
+            return this.SelectAggregate<T>(query, "avg", new[] { column });
         }
 
-        public async Task<T> SelectAverageAsync<T>(Query query, string column)
+        public async Task<T> SelectAverageAsync<T>(Query query, string column, CancellationToken cancellationToken = default)
         {
-            return await this.SelectAggregateAsync<T>(query, "avg", new[] { column });
+            return await this.SelectAggregateAsync<T>(query, "avg", new[] { column }, cancellationToken: cancellationToken);
         }
 
-        public T Sum<T>(Query query, string column)
+        public T SelectSum<T>(Query query, string column)
         {
-            return this.Aggregate<T>(query, "sum", new[] { column });
+            return this.SelectAggregate<T>(query, "sum", new[] { column });
         }
 
-        public async Task<T> SelectSumAsync<T>(Query query, string column)
+        public async Task<T> SelectSumAsync<T>(Query query, string column, CancellationToken cancellationToken = default)
         {
-            return await this.SelectAggregateAsync<T>(query, "sum", new[] { column });
+            return await this.SelectAggregateAsync<T>(query, "sum", new[] { column }, cancellationToken: cancellationToken);
         }
 
-        public T Min<T>(Query query, string column)
+        public T SelectMin<T>(Query query, string column)
         {
-            return this.Aggregate<T>(query, "min", new[] { column });
+            return this.SelectAggregate<T>(query, "min", new[] { column });
         }
 
-        public async Task<T> SelectMinAsync<T>(Query query, string column)
+        public async Task<T> SelectMinAsync<T>(Query query, string column, CancellationToken cancellationToken = default)
         {
-            return await this.SelectAggregateAsync<T>(query, "min", new[] { column });
+            return await this.SelectAggregateAsync<T>(query, "min", new[] { column }, cancellationToken: cancellationToken);
         }
 
-        public T Max<T>(Query query, string column)
+        public T SelectMax<T>(Query query, string column)
         {
-            return this.Aggregate<T>(query, "max", new[] { column });
+            return this.SelectAggregate<T>(query, "max", new[] { column });
         }
 
-        public async Task<T> SelectMaxAsync<T>(Query query, string column)
+        public async Task<T> SelectMaxAsync<T>(Query query, string column, CancellationToken cancellationToken = default)
         {
-            return await this.SelectAggregateAsync<T>(query, "max", new[] { column });
+            return await this.SelectAggregateAsync<T>(query, "max", new[] { column }, cancellationToken: cancellationToken);
         }
 
         public PaginationResult<T> Paginate<T>(Query query, int page, int perPage = 25, IDbTransaction transaction = null, int? timeout = null)
@@ -453,7 +466,7 @@ namespace SqlKata.Execution
                 throw new ArgumentException("PerPage param should be greater than or equal to 1", nameof(perPage));
             }
 
-            var count = Count<long>(query.Clone(), null, transaction, timeout);
+            var count = SelectCount<long>(query.Clone(), null, transaction, timeout);
 
             IEnumerable<T> list;
 
@@ -476,7 +489,7 @@ namespace SqlKata.Execution
             };
         }
 
-        public async Task<PaginationResult<T>> PaginateAsync<T>(Query query, int page, int perPage = 25, IDbTransaction transaction = null, int? timeout = null)
+        public async Task<PaginationResult<T>> PaginateAsync<T>(Query query, int page, int perPage = 25, IDbTransaction transaction = null, int? timeout = null, CancellationToken cancellationToken = default)
         {
             if (page < 1)
             {
@@ -488,13 +501,13 @@ namespace SqlKata.Execution
                 throw new ArgumentException("PerPage param should be greater than or equal to 1", nameof(perPage));
             }
 
-            var count = await SelectCountAsync<long>(query.Clone(), null, transaction, timeout);
+            var count = await SelectCountAsync<long>(query.Clone(), null, transaction, timeout, cancellationToken);
 
             IEnumerable<T> list;
 
             if (count > 0)
             {
-                list = await GetAsync<T>(query.Clone().ForPage(page, perPage), transaction, timeout);
+                list = await GetAsync<T>(query.Clone().ForPage(page, perPage), transaction, timeout, cancellationToken);
             }
             else
             {
@@ -527,7 +540,7 @@ namespace SqlKata.Execution
 
             while (result.HasNext)
             {
-                result = result.Next();
+                result = result.Next(transaction);
                 if (!func(result.List, result.Page))
                 {
                     return;
@@ -540,10 +553,11 @@ namespace SqlKata.Execution
             int chunkSize,
             Func<IEnumerable<T>, int, bool> func,
             IDbTransaction transaction = null,
-            int? timeout = null
+            int? timeout = null,
+            CancellationToken cancellationToken = default
         )
         {
-            var result = await this.PaginateAsync<T>(query, 1, chunkSize);
+            var result = await this.PaginateAsync<T>(query, 1, chunkSize, transaction, cancellationToken: cancellationToken);
 
             if (!func(result.List, 1))
             {
@@ -552,7 +566,7 @@ namespace SqlKata.Execution
 
             while (result.HasNext)
             {
-                result = result.Next();
+                result = result.Next(transaction);
                 if (!func(result.List, result.Page))
                 {
                     return;
@@ -568,7 +582,7 @@ namespace SqlKata.Execution
 
             while (result.HasNext)
             {
-                result = result.Next();
+                result = result.Next(transaction);
                 action(result.List, result.Page);
             }
         }
@@ -578,16 +592,17 @@ namespace SqlKata.Execution
             int chunkSize,
             Action<IEnumerable<T>, int> action,
             IDbTransaction transaction = null,
-            int? timeout = null
+            int? timeout = null,
+            CancellationToken cancellationToken = default
         )
         {
-            var result = await this.PaginateAsync<T>(query, 1, chunkSize, transaction, timeout);
+            var result = await this.PaginateAsync<T>(query, 1, chunkSize, transaction, timeout, cancellationToken);
 
             action(result.List, 1);
 
             while (result.HasNext)
             {
-                result = result.Next();
+                result = result.Next(transaction);
                 action(result.List, result.Page);
             }
         }
@@ -602,14 +617,16 @@ namespace SqlKata.Execution
             );
         }
 
-        public async Task<IEnumerable<T>> SelectAsync<T>(string sql, object param = null, IDbTransaction transaction = null, int? timeout = null)
+        public async Task<IEnumerable<T>> SelectAsync<T>(string sql, object param = null, IDbTransaction transaction = null, int? timeout = null, CancellationToken cancellationToken = default)
         {
-            return await this.Connection.QueryAsync<T>(
-                sql,
-                param,
+            var commandDefinition = new CommandDefinition(
+                commandText: sql,
+                parameters: param,
                 transaction: transaction,
-                commandTimeout: timeout ?? this.QueryTimeout
-            );
+                commandTimeout: timeout ?? this.QueryTimeout,
+                cancellationToken: cancellationToken);
+
+            return await this.Connection.QueryAsync<T>(commandDefinition);
         }
 
         public IEnumerable<dynamic> Select(string sql, object param = null, IDbTransaction transaction = null, int? timeout = null)
@@ -617,9 +634,9 @@ namespace SqlKata.Execution
             return this.Select<dynamic>(sql, param, transaction, timeout);
         }
 
-        public async Task<IEnumerable<dynamic>> SelectAsync(string sql, object param = null, IDbTransaction transaction = null, int? timeout = null)
+        public async Task<IEnumerable<dynamic>> SelectAsync(string sql, object param = null, IDbTransaction transaction = null, int? timeout = null, CancellationToken cancellationToken = default)
         {
-            return await this.SelectAsync<dynamic>(sql, param, transaction, timeout);
+            return await this.SelectAsync<dynamic>(sql, param, transaction, timeout, cancellationToken);
         }
 
         public int Statement(string sql, object param = null, IDbTransaction transaction = null, int? timeout = null)
@@ -627,9 +644,15 @@ namespace SqlKata.Execution
             return this.Connection.Execute(sql, param, transaction: transaction, commandTimeout: timeout ?? this.QueryTimeout);
         }
 
-        public async Task<int> StatementAsync(string sql, object param = null, IDbTransaction transaction = null, int? timeout = null)
+        public async Task<int> StatementAsync(string sql, object param = null, IDbTransaction transaction = null, int? timeout = null, CancellationToken cancellationToken = default)
         {
-            return await this.Connection.ExecuteAsync(sql, param, transaction: transaction, commandTimeout: timeout ?? this.QueryTimeout);
+            var commandDefinition = new CommandDefinition(
+                commandText: sql,
+                parameters: param,
+                transaction: transaction,
+                commandTimeout: timeout ?? this.QueryTimeout,
+                cancellationToken: cancellationToken);
+            return await this.Connection.ExecuteAsync(commandDefinition);
         }
 
         private static IEnumerable<T> handleIncludes<T>(Query query, IEnumerable<T> result)
@@ -734,7 +757,7 @@ namespace SqlKata.Execution
             return dynamicResult.Cast<T>();
         }
 
-        private static async Task<IEnumerable<T>> handleIncludesAsync<T>(Query query, IEnumerable<T> result)
+        private static async Task<IEnumerable<T>> handleIncludesAsync<T>(Query query, IEnumerable<T> result, CancellationToken cancellationToken = default)
         {
             if (!result.Any())
             {
@@ -784,7 +807,7 @@ namespace SqlKata.Execution
                         continue;
                     }
 
-                    var children = (await include.Query.WhereIn(include.ForeignKey, localIds).GetAsync())
+                    var children = (await include.Query.WhereIn(include.ForeignKey, localIds).GetAsync(cancellationToken: cancellationToken))
                         .Cast<IDictionary<string, object>>()
                         .Select(x => new Dictionary<string, object>(x, StringComparer.OrdinalIgnoreCase))
                         .GroupBy(x => x[include.ForeignKey].ToString())
@@ -813,7 +836,7 @@ namespace SqlKata.Execution
                     continue;
                 }
 
-                var related = (await include.Query.WhereIn(include.LocalKey, foreignIds).GetAsync())
+                var related = (await include.Query.WhereIn(include.LocalKey, foreignIds).GetAsync(cancellationToken: cancellationToken))
                     .Cast<IDictionary<string, object>>()
                     .Select(x => new Dictionary<string, object>(x, StringComparer.OrdinalIgnoreCase))
                     .ToDictionary(x => x[include.LocalKey].ToString());


### PR DESCRIPTION
During the merge a few places where e.g. `SelectCount()` was left as `Count()` seem to have been found. If a cleaner merge is desired I can try to make a pass to make a separate PR for that, but it's a bit of a PITA.